### PR TITLE
Tasks/Issues Closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ phx_new_cache-*.tar
 # Ignore digested assets cache.
 /priv/static/cache_manifest.json
 
+# Ignore uploaded files (stored on persistent volume in production)
+/priv/static/uploads/
+
+# Ignore local databases
+*.db
+
 # In case you use Node.js/npm, you want to ignore these.
 npm-debug.log
 /assets/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,12 @@ ENV LC_ALL en_US.UTF-8
 WORKDIR "/app"
 RUN chown nobody /app
 
+# Create symlink so that /app/priv/static/uploads points to the persistent volume
+# This ensures uploaded files survive deploys
+RUN mkdir -p /data/uploads && \
+    ln -s /data/uploads /app/priv/static/uploads && \
+    chown -R nobody /data
+
 # set runner ENV
 ENV MIX_ENV="prod"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,9 +28,15 @@ if config_env() == :prod do
       For example: /etc/mykonos_biennale/mykonos_biennale.db
       """
 
+database_dir = Path.dirname(database_path)
+  File.mkdir_p(database_dir)
+
   config :mykonos_biennale, MykonosBiennale.Repo,
     database: database_path,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5")
+
+  config :mykonos_biennale, :uploads_dir, "/data/uploads"
+  File.mkdir_p!("/data/uploads")
 
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,10 @@ app = "mykonos-biennale"
 primary_region = "ams"
 kill_signal = "SIGTERM"
 
+[mounts]
+  source = "data"
+  destination = "/data"
+
 [build]
 
 [deploy]
@@ -15,6 +19,7 @@ kill_signal = "SIGTERM"
 [env]
   PHX_HOST = "mykonos-biennale-bitter-sea-4396.fly.dev"
   PORT = "8080"
+  DATABASE_PATH = "/data/mykonos_biennale.db"
 
 [http_service]
   internal_port = 8080

--- a/lib/mix/tasks/app.dump.ex
+++ b/lib/mix/tasks/app.dump.ex
@@ -1,0 +1,72 @@
+defmodule Mix.Tasks.App.Dump do
+  @moduledoc """
+  Dumps all application data to a JSON file for migration between databases.
+
+  Usage:
+      mix app.dump                      # dumps to priv/repo/data_dump.json
+      mix app.dump --output mydata.json # dumps to specified file
+  """
+  use Mix.Task
+
+  alias MykonosBiennale.Repo
+  alias MykonosBiennale.Content.{Entity, Relationship, RelationshipType, Media, EntityMedia}
+  alias MykonosBiennale.Site.{Page, Section}
+  alias MykonosBiennale.Accounts.{User, UserToken}
+
+  @shortdoc "Dump all data to JSON"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, switches: [output: :string])
+
+    Mix.Task.run("app.start", [])
+
+    output = opts[:output] || "priv/repo/data_dump.json"
+
+    data = %{
+      relationship_types: dump(RelationshipType),
+      users: dump(User),
+      user_tokens: dump(UserToken),
+      entities: dump(Entity),
+      media: dump(Media),
+      entity_media: dump(EntityMedia),
+      relationships: dump(Relationship),
+      pages: dump(Page),
+      sections: dump(Section)
+    }
+
+    File.mkdir_p!(Path.dirname(output))
+    File.write!(output, Jason.encode!(data, pretty: true))
+
+    counts = for {k, v} <- data, into: %{}, do: {k, length(v)}
+    IO.puts("Dumped #{length(Map.keys(counts))} tables to #{output}")
+    for {k, v} <- Enum.sort(counts), do: IO.puts("  #{k}: #{v} records")
+  end
+
+  defp dump(schema) do
+    Repo.all(schema)
+    |> Enum.map(&serialize_record/1)
+  end
+
+  defp serialize_record(record) do
+    record
+    |> Map.from_struct()
+    |> Map.drop([:__meta__, :as_subject, :as_object, :media, :sections, :entities, :page, :user, :relationship_type, :subject, :object])
+    |> Enum.map(fn
+      {:inserted_at, %NaiveDateTime{} = dt} -> {:inserted_at, NaiveDateTime.to_iso8601(dt)}
+      {:updated_at, %NaiveDateTime{} = dt} -> {:updated_at, NaiveDateTime.to_iso8601(dt)}
+      {:inserted_at, nil} -> {:inserted_at, nil}
+      {:updated_at, nil} -> {:updated_at, nil}
+      {:search_indexed_at, %NaiveDateTime{} = dt} -> {:search_indexed_at, NaiveDateTime.to_iso8601(dt)}
+      {:search_indexed_at, nil} -> {:search_indexed_at, nil}
+      {:fields, val} when is_map(val) -> {:fields, val}
+      {:metadata, val} when is_map(val) -> {:metadata, val}
+      {:hashed_password, bin} when is_binary(bin) -> {:hashed_password, Base.encode64(bin)}
+      {:token, bin} when is_binary(bin) -> {:token, Base.encode64(bin)}
+      {_k, %Ecto.Association.NotLoaded{}} -> nil
+      other -> other
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Map.new()
+  end
+end

--- a/lib/mix/tasks/app.restore.ex
+++ b/lib/mix/tasks/app.restore.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.App.Restore do
     relationship_types: ~w(id label slug inserted_at updated_at)a,
     users: ~w(id email hashed_password confirmed_at inserted_at updated_at)a,
     users_tokens: ~w(id token context sent_to authenticated_at user_id inserted_at)a,
-    entities: ~w(id identity type slug visible fields search_index search_indexed_at inserted_at updated_at)a,
+    entities: ~w(id identity type slug visible template fields search_index search_indexed_at inserted_at updated_at)a,
     media: ~w(id caption source_type source_url source_embed source_path mime_type alt_text metadata search_index search_indexed_at inserted_at updated_at)a,
     entity_media: ~w(entity_id media_id position metadata inserted_at updated_at)a,
     relationships: ~w(id fields relationship_type_id subject_id object_id inserted_at updated_at)a,
@@ -106,6 +106,7 @@ defmodule Mix.Tasks.App.Restore do
       {"token", s} when is_binary(s) -> {:token, Base.decode64!(s)}
       {"visible", true} -> {:visible, 1}
       {"visible", false} -> {:visible, 0}
+      {"template", nil} -> {:template, "default"}
       {k, v} when is_map(v) -> {String.to_atom(k), Jason.encode!(v)}
       {k, v} when is_binary(k) -> {String.to_atom(k), v}
     end)

--- a/lib/mix/tasks/app.restore.ex
+++ b/lib/mix/tasks/app.restore.ex
@@ -1,0 +1,114 @@
+defmodule Mix.Tasks.App.Restore do
+  @moduledoc """
+  Restores application data from a JSON dump file.
+
+  This will DELETE existing data and replace it with the dump contents.
+  Useful for seeding production or syncing local dev with production data.
+
+  Usage:
+      mix app.restore                      # restores from priv/repo/data_dump.json
+      mix app.restore --input mydata.json # restores from specified file
+  """
+  use Mix.Task
+
+  alias MykonosBiennale.Repo
+
+  @shortdoc "Restore all data from a JSON dump"
+
+  @table_order ~w(sections pages relationships entity_media media entities users_tokens users relationship_types)
+
+  @columns %{
+    relationship_types: ~w(id label slug inserted_at updated_at)a,
+    users: ~w(id email hashed_password confirmed_at inserted_at updated_at)a,
+    users_tokens: ~w(id token context sent_to authenticated_at user_id inserted_at)a,
+    entities: ~w(id identity type slug visible fields search_index search_indexed_at inserted_at updated_at)a,
+    media: ~w(id caption source_type source_url source_embed source_path mime_type alt_text metadata search_index search_indexed_at inserted_at updated_at)a,
+    entity_media: ~w(entity_id media_id position metadata inserted_at updated_at)a,
+    relationships: ~w(id fields relationship_type_id subject_id object_id inserted_at updated_at)a,
+    pages: ~w(id position title slug description template content visible metadata inserted_at updated_at)a,
+    sections: ~w(id position title slug description template content visible metadata page_id inserted_at updated_at)a
+  }
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, switches: [input: :string])
+
+    Mix.Task.run("app.start", [])
+
+    input = opts[:input] || "priv/repo/data_dump.json"
+
+    unless File.exists?(input) do
+      IO.puts("ERROR: File not found: #{input}")
+      exit(:shutdown)
+    end
+
+    data = input
+           |> File.read!()
+           |> Jason.decode!()
+
+    IO.puts("Restoring data from #{input}...")
+
+    Repo.transaction(fn ->
+      truncate_tables()
+      restore_in_order(data)
+    end)
+
+    IO.puts("\nRestore complete!")
+    for key <- ~w(relationship_types users user_tokens entities media entity_media relationships pages sections) do
+      records = Map.get(data, key, [])
+      IO.puts("  #{key}: #{length(records)} records")
+    end
+  end
+
+  defp restore_in_order(data) do
+    do_restore(:relationship_types, "relationship_types", "relationship_types", data)
+    do_restore(:users, "users", "users", data)
+    do_restore(:users_tokens, "user_tokens", "users_tokens", data)
+    do_restore(:entities, "entities", "entities", data)
+    do_restore(:media, "media", "media", data)
+    do_restore(:entity_media, "entity_media", "entity_media", data)
+    do_restore(:relationships, "relationships", "relationships", data)
+    do_restore(:pages, "pages", "pages", data)
+    do_restore(:sections, "sections", "sections", data)
+  end
+
+  defp do_restore(col_key, json_key, db_table, data) do
+    records = Map.get(data, json_key, [])
+    columns = Map.fetch!(@columns, col_key)
+    cols_sql = "(" <> Enum.map_join(columns, ", ", &"\"#{&1}\"") <> ")"
+    placeholders = "(" <> Enum.map_join(columns, ", ", fn _ -> "?" end) <> ")"
+    sql = "INSERT INTO #{db_table} #{cols_sql} VALUES #{placeholders}"
+
+    for record <- records do
+      deserialized = deserialize_record(record)
+      values = Enum.map(columns, fn col -> Map.get(deserialized, col) end)
+      Repo.query!(sql, values)
+    end
+
+    IO.puts("  Restored #{length(records)} #{db_table}")
+  end
+
+  defp truncate_tables do
+    if Repo.__adapter__() == Ecto.Adapters.SQLite3 do
+      Repo.query!("PRAGMA foreign_keys = OFF")
+      for table <- @table_order, do: Repo.query!("DELETE FROM #{table}")
+      Repo.query!("DELETE FROM sqlite_sequence")
+      Repo.query!("PRAGMA foreign_keys = ON")
+    else
+      Repo.query!("TRUNCATE TABLE #{Enum.join(@table_order, ", ")} CASCADE")
+    end
+  end
+
+  defp deserialize_record(record) do
+    record
+    |> Enum.map(fn
+      {"hashed_password", s} when is_binary(s) -> {:hashed_password, Base.decode64!(s)}
+      {"token", s} when is_binary(s) -> {:token, Base.decode64!(s)}
+      {"visible", true} -> {:visible, 1}
+      {"visible", false} -> {:visible, 0}
+      {k, v} when is_map(v) -> {String.to_atom(k), Jason.encode!(v)}
+      {k, v} when is_binary(k) -> {String.to_atom(k), v}
+    end)
+    |> Map.new()
+  end
+end

--- a/lib/mykonos_biennale/content/biennale.ex
+++ b/lib/mykonos_biennale/content/biennale.ex
@@ -58,6 +58,7 @@ defmodule MykonosBiennale.Content.Biennale do
       type: "biennale",
       slug: to_string(year),
       visible: Map.get(attrs, :visible, true),
+      template: Map.get(attrs, :template, :default),
       fields: fields
     })
   end
@@ -84,6 +85,7 @@ defmodule MykonosBiennale.Content.Biennale do
       identity: to_string(new_fields["year"]),
       slug: to_string(new_fields["year"]),
       visible: Map.get(attrs, :visible, biennale_entity.visible),
+      template: Map.get(attrs, :template, biennale_entity.template),
       fields: new_fields
     })
   end

--- a/lib/mykonos_biennale/content/entity.ex
+++ b/lib/mykonos_biennale/content/entity.ex
@@ -7,6 +7,7 @@ defmodule MykonosBiennale.Content.Entity do
     field :type, :string
     field :slug, :string
     field :visible, :boolean, default: false
+    field :template, Ecto.Enum, values: [:none, :default], default: :default
     field :fields, :map
     field :search_index, :string
     field :search_indexed_at, :naive_datetime
@@ -25,7 +26,7 @@ defmodule MykonosBiennale.Content.Entity do
   @doc false
   def changeset(entity, attrs, _meta \\ []) do
     entity
-    |> cast(attrs, [:identity, :type, :slug, :visible, :fields, :search_index, :search_indexed_at])
+    |> cast(attrs, [:identity, :type, :slug, :visible, :template, :fields, :search_index, :search_indexed_at])
     |> validate_required([:identity, :type, :slug, :visible])
   end
 end

--- a/lib/mykonos_biennale/release.ex
+++ b/lib/mykonos_biennale/release.ex
@@ -1,0 +1,22 @@
+defmodule MykonosBiennale.Release do
+  @moduledoc """
+  Used for production tasks like running migrations.
+  """
+  @app :mykonos_biennale
+
+  def migrate do
+    load_app()
+
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  def rollback(repo, version) do
+    load_app()
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  defp repos, do: Application.fetch_env!(@app, :ecto_repos)
+  defp load_app, do: Application.load(@app)
+end

--- a/lib/mykonos_biennale/uploads.ex
+++ b/lib/mykonos_biennale/uploads.ex
@@ -1,0 +1,25 @@
+defmodule MykonosBiennale.Uploads do
+  @moduledoc """
+  Centralized upload path configuration.
+
+  In development, uploads are stored in priv/static/uploads.
+  In production, they are stored on the persistent volume at /data/uploads.
+  """
+
+  def uploads_dir do
+    Application.get_env(:mykonos_biennale, :uploads_dir) ||
+      Path.join(["priv", "static", "uploads"])
+  end
+
+  def uploads_path(filename) do
+    Path.join([uploads_dir(), filename])
+  end
+
+  def uploads_url(filename) when is_binary(filename) do
+    "/uploads/#{filename}"
+  end
+
+  def ensure_uploads_dir do
+    File.mkdir_p!(uploads_dir())
+  end
+end

--- a/lib/mykonos_biennale/workers/import_festival.ex
+++ b/lib/mykonos_biennale/workers/import_festival.ex
@@ -818,7 +818,6 @@ defmodule MykonosBiennale.Workers.ImportFestival do
   end
 
   @s3_base "https://s3.amazonaws.com/com.mykonosbiennale.static/"
-  @uploads_dir "priv/static/uploads"
 
   defp download_s3_image(url) do
     filename =
@@ -828,11 +827,11 @@ defmodule MykonosBiennale.Workers.ImportFestival do
       |> URI.decode()
 
     local_filename = "#{Ecto.UUID.generate()}#{Path.extname(filename)}"
-    local_path = Path.join(@uploads_dir, local_filename)
+    local_path = MykonosBiennale.Uploads.uploads_path(local_filename)
 
     case Req.get(url, receive_timeout: 30_000) do
       {:ok, %{status: 200, body: body}} ->
-        File.mkdir_p!(@uploads_dir)
+        MykonosBiennale.Uploads.ensure_uploads_dir()
         File.write!(local_path, body)
         {:ok, local_filename}
 

--- a/lib/mykonos_biennale/workers/import_filmfestival.ex
+++ b/lib/mykonos_biennale/workers/import_filmfestival.ex
@@ -719,7 +719,6 @@ defmodule MykonosBiennale.Workers.ImportFilmfestival do
   ## -- Media helpers --
 
   @s3_base "https://s3.amazonaws.com/com.mykonosbiennale.static/"
-  @uploads_dir "priv/static/uploads"
 
   defp download_s3_image(url) do
     filename =
@@ -729,11 +728,11 @@ defmodule MykonosBiennale.Workers.ImportFilmfestival do
       |> URI.decode()
 
     local_filename = "#{Ecto.UUID.generate()}#{Path.extname(filename)}"
-    local_path = Path.join(@uploads_dir, local_filename)
+    local_path = MykonosBiennale.Uploads.uploads_path(local_filename)
 
     case Req.get(url, receive_timeout: 30_000) do
       {:ok, %{status: 200, body: body}} ->
-        File.mkdir_p!(@uploads_dir)
+        MykonosBiennale.Uploads.ensure_uploads_dir()
         File.write!(local_path, body)
         {:ok, local_filename}
 

--- a/lib/mykonos_biennale_web/controllers/biennale_controller.ex
+++ b/lib/mykonos_biennale_web/controllers/biennale_controller.ex
@@ -2,20 +2,20 @@ defmodule MykonosBiennaleWeb.BiennaleController do
   use MykonosBiennaleWeb, :controller
 
   alias MykonosBiennale.Content
+  alias MykonosBiennaleWeb.BiennaleHTML
 
   def show(conn, %{"slug" => slug}) do
     case Content.get_entity_by_slug(slug) do
       %{type: "biennale", visible: true} = biennale ->
-        year = parse_year(biennale.fields["year"])
-        events = Content.list_events_for_biennale(year) |> Enum.map(&present_event/1)
-        biennale_media = Content.list_media_for_entity(biennale)
-
         conn
         |> assign(:biennale, biennale)
-        |> assign(:biennale_media, biennale_media)
-        |> assign(:events, events)
-        |> assign(:page_title, "#{biennale.fields["theme"]} — Mykonos Biennale #{biennale.fields["year"]}")
-        |> render(:biennale)
+        |> assign(:events, load_events(biennale))
+        |> assign(:biennale_media, Content.list_media_for_entity(biennale))
+        |> assign(
+          :page_title,
+          "#{biennale.fields["theme"]} — Mykonos Biennale #{biennale.fields["year"]}"
+        )
+        |> render_template(biennale)
 
       %{visible: false} ->
         not_found(conn)
@@ -26,6 +26,28 @@ defmodule MykonosBiennaleWeb.BiennaleController do
       _ ->
         not_found(conn)
     end
+  end
+
+  defp load_events(biennale) do
+    year = parse_year(biennale.fields["year"])
+    Content.list_events_for_biennale(year) |> Enum.map(&present_event/1)
+  end
+
+  defp render_template(conn, %{template: :none}) do
+    biennale = conn.assigns.biennale
+    content = BiennaleHTML.render_content(biennale.fields["content"], conn.assigns)
+
+    conn
+    |> assign(:page_content, content)
+    |> render(:none)
+  end
+
+  defp render_template(conn, "list") do
+    render(conn, :list)
+  end
+
+  defp render_template(conn, _template) do
+    render(conn, :biennale)
   end
 
   defp present_event(%MykonosBiennale.Content.Entity{} = entity) do
@@ -56,6 +78,7 @@ defmodule MykonosBiennaleWeb.BiennaleController do
 
   defp parse_year(nil), do: nil
   defp parse_year(y) when is_integer(y), do: y
+
   defp parse_year(y) when is_binary(y) do
     case Integer.parse(y) do
       {n, _} -> n

--- a/lib/mykonos_biennale_web/controllers/biennale_html.ex
+++ b/lib/mykonos_biennale_web/controllers/biennale_html.ex
@@ -15,4 +15,57 @@ defmodule MykonosBiennaleWeb.BiennaleHTML do
     end
   end
   def format_date(%Date{} = d), do: Calendar.strftime(d, "%B %d, %Y")
+
+  def render_content(nil, _assigns), do: Phoenix.HTML.raw("")
+
+  def render_content(content, assigns) when is_binary(content) and is_map(assigns) do
+    ast =
+      EEx.compile_string(content,
+        engine: Phoenix.LiveView.TagEngine,
+        line: 1,
+        file: "biennale_content",
+        trim: true,
+        caller: caller_env(),
+        source: content,
+        tag_handler: Phoenix.LiveView.HTMLEngine
+      )
+
+    {rendered, _} = Code.eval_quoted(ast, [assigns: assigns], caller_env())
+
+    html =
+      rendered
+      |> render_to_iodata()
+      |> IO.iodata_to_binary()
+
+    Phoenix.HTML.raw(strip_debug_annotations(html))
+  rescue
+    _ ->
+      Phoenix.HTML.raw(content)
+  end
+
+  defp caller_env do
+    env = __ENV__
+    %{env | file: "biennale_content", line: 1}
+  end
+
+  defp render_to_iodata(%Phoenix.LiveView.Rendered{static: static, dynamic: dynamic})
+       when is_function(dynamic, 1) do
+    parts = dynamic.(nil)
+    interleave(static, parts)
+  end
+
+  defp render_to_iodata(%Phoenix.LiveView.Rendered{static: static, dynamic: nil}), do: static
+  defp render_to_iodata(iodata) when is_list(iodata), do: iodata
+  defp render_to_iodata(binary) when is_binary(binary), do: binary
+
+  defp interleave([static_part | rest_static], [dynamic_part | rest_dynamic]) do
+    [static_part | [render_to_iodata(dynamic_part) | interleave(rest_static, rest_dynamic)]]
+  end
+
+  defp interleave([static_part], []), do: [static_part]
+  defp interleave([], []), do: []
+
+  defp strip_debug_annotations(html) do
+    Regex.replace(~r/<!--\s*<\/?[\w.]+>\s*[^-]*?-->/, html, "")
+  end
 end

--- a/lib/mykonos_biennale_web/controllers/biennale_html/biennale.html.heex
+++ b/lib/mykonos_biennale_web/controllers/biennale_html/biennale.html.heex
@@ -35,18 +35,31 @@
 
   <%!-- Events Grid --%>
   <%= if @events != [] do %>
+    <% remainder = rem(length(@events), 4) %>
+    <% {last_span, penultimate_span} = cond do
+      remainder == 1 -> {"lg:col-span-4", "lg:col-span-2 md:col-span-1"}
+      remainder == 3 -> {"lg:col-span-2", nil}
+      true -> {nil, nil}
+    end %>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
-      <%= for event <- @events do %>
-        <div class="flex flex-col h-full border-b border-r border-gray-100 text-[#444]">
+      <%= for {event, idx} <- Enum.with_index(@events) do %>
+        <% is_last = idx == length(@events) - 1 %>
+        <% is_penultimate = idx == length(@events) - 2 %>
+        <% span_class = cond do
+          is_last && last_span -> last_span
+          is_penultimate && penultimate_span -> penultimate_span
+          true -> ""
+        end %>
+        <div class={["flex flex-col h-full border-b border-r border-gray-100 text-[#444]", span_class]}>
           <div :if={event.background_image} class="h-64 bg-cover bg-center" style={"background-image: url('#{event.background_image}');"}></div>
           <div :if={is_nil(event.background_image)} class="h-64 bg-gradient-to-br from-gray-200 to-gray-300 flex items-center justify-center">
             <span class="text-5xl text-gray-400">{String.slice(event.title || "", 0, 1)}</span>
           </div>
-          <div class={"#{if rem(Enum.find_index(@events, &(&1.id == event.id)) || 0, 2) == 0, do: "bg-gray-50", else: "bg-white"} flex-grow p-8"}>
+          <div class={"#{if rem(idx, 2) == 0, do: "bg-gray-50", else: "bg-white"} flex-grow p-8"}>
             <h3 class="text-xl font-bold uppercase mb-4">{event.title}</h3>
-            <%= if event.date do %>
+            <%!-- <%= if event.date do %>
               <p class="text-xs font-bold text-gray-400 mb-4 uppercase tracking-widest">{format_date(event.date)}</p>
-            <% end %>
+            <% end %> --%>
             <%= if event.description do %>
               <p class="text-sm leading-relaxed text-gray-600 mb-4">{event.description}</p>
             <% end %>

--- a/lib/mykonos_biennale_web/controllers/biennale_html/list.html.heex
+++ b/lib/mykonos_biennale_web/controllers/biennale_html/list.html.heex
@@ -41,7 +41,7 @@
       remainder == 3 -> {"lg:col-span-2", nil}
       true -> {nil, nil}
     end %>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
+    <div class="">
       <%= for {event, idx} <- Enum.with_index(@events) do %>
         <% is_last = idx == length(@events) - 1 %>
         <% is_penultimate = idx == length(@events) - 2 %>
@@ -52,11 +52,11 @@
         end %>
 
         <div class={["flex flex-col h-full border-b border-r border-gray-100 text-[#444]", span_class]}>
-          <div :if={event.background_image} class="h-64 bg-cover bg-center" style={"background-image: url('#{event.background_image}');"}></div>
-          <div :if={is_nil(event.background_image)} class="h-64 bg-gradient-to-br from-gray-200 to-gray-300 flex items-center justify-center">
+          <div :if={event.background_image} class="h-[80vh] bg-cover bg-top_5em" style={"background-image: url('#{event.background_image}');"}></div>
+          <%!-- <div :if={is_nil(event.background_image)} class="h-[80vh] bg-gradient-to-br from-gray-200 to-gray-300 flex items-center justify-center">
             <span class="text-5xl text-gray-400">{String.slice(event.title || "", 0, 1)}</span>
-          </div>
-          <div class={"#{if rem(idx, 2) == 0, do: "bg-gray-50", else: "bg-white"} flex-grow p-8"}>
+          </div> --%>
+          <div class="bg-white flex-grow p-8">
             <h3 class="text-xl font-bold uppercase mb-4">{event.title}</h3>
             <%!-- <%= if event.date do %>
               <p class="text-xs font-bold text-gray-400 mb-4 uppercase tracking-widest">{format_date(event.date)}</p>

--- a/lib/mykonos_biennale_web/controllers/biennale_html/none.html.heex
+++ b/lib/mykonos_biennale_web/controllers/biennale_html/none.html.heex
@@ -1,0 +1,1 @@
+<%= @page_content %>

--- a/lib/mykonos_biennale_web/controllers/page_html/home.html.heex
+++ b/lib/mykonos_biennale_web/controllers/page_html/home.html.heex
@@ -145,7 +145,7 @@
         Archive
       </h2>
 
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div class="aspect-square bg-black border border-gray-800 flex items-center justify-center hover:bg-gray-900 transition-colors cursor-pointer">
           <span class="text-3xl font-bold text-gray-600">2024</span>
         </div>

--- a/lib/mykonos_biennale_web/controllers/site_page_html/biennale.html.heex
+++ b/lib/mykonos_biennale_web/controllers/site_page_html/biennale.html.heex
@@ -63,7 +63,7 @@
     </div>
 
         <!-- grid of events -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1">
  <!-- event -->
         <div class="flex flex-col h-full border-b border-r border-gray-100">
 

--- a/lib/mykonos_biennale_web/controllers/site_page_html/none.html.heex
+++ b/lib/mykonos_biennale_web/controllers/site_page_html/none.html.heex
@@ -63,11 +63,11 @@
     </div>
 
         <!-- grid of events -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+    <div class="">
  <!-- event -->
         <div class="flex flex-col h-full border-b border-r border-gray-100">
 
-                    <div class="h-64 bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos_biennale-antidote-2021-delos-960.webp');"></div>
+                    <div class="h-[75vh] bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos_biennale-antidote-2021-delos-960.webp');"></div>
 
             <div class="bg-gray-50 flex-grow p-8">
                 <h3 class="text-xl font-bold uppercase mb-4">Treasure Hunt - Antidote</h3>
@@ -77,7 +77,7 @@
         </div>
  <!-- event -->
         <div class="flex flex-col h-full border-b border-r border-gray-100">
-            <div class="h-64 bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos_biennale-garden_of_mysteries-2023.webp');"></div>
+            <div class="h-[75vh] bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos_biennale-garden_of_mysteries-2023.webp');"></div>
             <div class="bg-white flex-grow p-8">
                 <h3 class="text-xl font-bold uppercase mb-4">GARDEN OF MYSTERIES</h3>
                 <p class="text-xs font-bold text-gray-400 mb-4 uppercase tracking-widest">Participating Artists</p>
@@ -88,7 +88,7 @@
         </div>
  <!-- event -->
         <div class="flex flex-col h-full border-b border-gray-100">
-            <div class="h-64 bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos-biennale-2021-dramatic-nights-x.webp');"></div>
+            <div class="h-[75vh] bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos-biennale-2021-dramatic-nights-x.webp');"></div>
             <div class="bg-gray-50 flex-grow p-8">
                 <h3 class="text-xl font-bold uppercase mb-4">Dramatic Nights</h3>
                 <p class="text-sm leading-relaxed text-gray-600 mb-4">A short film festival held at the Venieri house of Ano Mera, screening the Official 2023 Selection selection from around the world.</p>
@@ -97,7 +97,7 @@
         </div>
  <!-- event -->
         <div class="flex flex-col h-full border-b border-r border-gray-100">
-            <div class="h-64 bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos-biennale-2021-video-graffiti-x.webp');"></div>
+            <div class="h-[75vh] bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos-biennale-2021-video-graffiti-x.webp');"></div>
             <div class="bg-white flex-grow p-8">
                 <h3 class="text-xl font-bold uppercase mb-4">Video Graffiti</h3>
                 <p class="text-sm leading-relaxed text-gray-600 mb-4">Official selections projected on the walls of houses and garden walls in the old town, transforming Chora into a living theatre.</p>
@@ -106,7 +106,7 @@
         </div>
  <!-- event -->
         <div class="flex flex-col h-full border-b border-r border-gray-100">
-            <div class="h-64 bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos-biennale-2019-film-festival-embraces-the-touch-of-skin-embraces-the-touch-of-skin-sara-koppel-Screenshot-1.webp');"></div>
+            <div class="h-[75vh] bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos-biennale-2019-film-festival-embraces-the-touch-of-skin-embraces-the-touch-of-skin-sara-koppel-Screenshot-1.webp');"></div>
             <div class="bg-gray-50 flex-grow p-8">
                 <h3 class="text-xl font-bold uppercase mb-4">Animation</h3>
                 <p class="text-sm leading-relaxed text-gray-600">In the garden of the Venieri Tower in Ann Mera, the official Animation Official 2023 selection will be projected.</p>
@@ -114,7 +114,7 @@
         </div>
  <!-- event -->
         <div class="flex flex-col h-full border-b border-gray-100">
-            <div class="h-64 bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos-biennale-2021-film-festival-numbness-numbness-1-hamid-nezamzadeh-Screenshot-13.webp');"></div>
+            <div class="h-[75vh] bg-cover bg-center" style="background-image: url('https://mykonosbiennale.com/static/images/mykonos-biennale-2021-film-festival-numbness-numbness-1-hamid-nezamzadeh-Screenshot-13.webp');"></div>
             <div class="bg-white flex-grow p-8">
                 <h3 class="text-xl font-bold uppercase mb-4">Urban</h3>
                 <p class="text-sm leading-relaxed text-gray-600">In the garden of the Venieri Tower in Ann Mera, the official Urban Official 2023 selection will be projected.</p>

--- a/lib/mykonos_biennale_web/endpoint.ex
+++ b/lib/mykonos_biennale_web/endpoint.ex
@@ -26,6 +26,13 @@ defmodule MykonosBiennaleWeb.Endpoint do
     gzip: not code_reloading?,
     only: MykonosBiennaleWeb.static_paths()
 
+  if Application.get_env(:mykonos_biennale, :uploads_dir) do
+    plug Plug.Static,
+      at: "/uploads",
+      from: Application.get_env(:mykonos_biennale, :uploads_dir),
+      gzip: not code_reloading?
+  end
+
   if Mix.env() == :dev do
     plug Tidewave
   end

--- a/lib/mykonos_biennale_web/live/admin/artwork_live/form_component.ex
+++ b/lib/mykonos_biennale_web/live/admin/artwork_live/form_component.ex
@@ -608,8 +608,8 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.FormComponent do
       consume_uploaded_entries(socket, :artwork_image, fn %{path: path}, entry ->
         ext = Path.extname(entry.client_name)
         filename = "#{Ecto.UUID.generate()}#{ext}"
-        dest = Path.join(["priv", "static", "uploads", filename])
-        File.mkdir_p!(Path.dirname(dest))
+        dest = MykonosBiennale.Uploads.uploads_path(filename)
+        MykonosBiennale.Uploads.ensure_uploads_dir()
         File.cp!(path, dest)
         {:ok, %{path: filename, mime_type: entry.client_type}}
       end)

--- a/lib/mykonos_biennale_web/live/admin/biennale_live/form_component.ex
+++ b/lib/mykonos_biennale_web/live/admin/biennale_live/form_component.ex
@@ -20,11 +20,21 @@ defmodule MykonosBiennaleWeb.Admin.BiennaleLive.FormComponent do
       field :start_date, :date
       field :end_date, :date
       field :visible, :boolean, default: true
+      field :template, Ecto.Enum, values: [:default, :none, :list], default: :default
     end
 
     def changeset(%__MODULE__{} = form, attrs) when is_map(attrs) do
       form
-      |> cast(attrs, [:year, :theme, :statement, :description, :start_date, :end_date, :visible])
+      |> cast(attrs, [
+        :year,
+        :theme,
+        :statement,
+        :description,
+        :start_date,
+        :end_date,
+        :visible,
+        :template
+      ])
       |> validate_required([:year, :theme])
     end
   end
@@ -47,6 +57,7 @@ defmodule MykonosBiennaleWeb.Admin.BiennaleLive.FormComponent do
         <div class="space-y-4">
           <.input field={@form[:year]} type="number" label="Year" required />
           <.input field={@form[:theme]} type="text" label="Theme" required />
+          <.input field={@form[:template]} type="select" label="Template" options={[{"Default", "default"}, {"None (raw content)", "none"}, {"List", "list"}]} />
           <.input field={@form[:statement]} type="textarea" label="Statement" rows="3" />
           <.input field={@form[:description]} type="textarea" label="Description" rows="5" />
           <.input field={@form[:start_date]} type="date" label="Start Date" />
@@ -347,7 +358,7 @@ defmodule MykonosBiennaleWeb.Admin.BiennaleLive.FormComponent do
   defp extract_biennale_params(%{"entity" => p}) when is_map(p), do: p
   defp extract_biennale_params(_), do: %{}
 
-  defp biennale_form_attrs(%Content.Entity{fields: fields}) when is_map(fields) do
+  defp biennale_form_attrs(%Content.Entity{fields: fields} = entity) when is_map(fields) do
     %{
       year: map_get_int(fields, "year"),
       theme: Map.get(fields, "theme"),
@@ -355,7 +366,8 @@ defmodule MykonosBiennaleWeb.Admin.BiennaleLive.FormComponent do
       description: Map.get(fields, "description"),
       start_date: map_get_date(fields, "start_date"),
       end_date: map_get_date(fields, "end_date"),
-      visible: true
+      visible: true,
+      template: entity.template || :default
     }
   end
 
@@ -403,7 +415,8 @@ defmodule MykonosBiennaleWeb.Admin.BiennaleLive.FormComponent do
       description: form.description,
       start_date: form.start_date,
       end_date: form.end_date,
-      visible: form.visible
+      visible: form.visible,
+      template: form.template
     }
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
     |> Enum.into(%{})

--- a/lib/mykonos_biennale_web/live/admin/film_live/form_component.ex
+++ b/lib/mykonos_biennale_web/live/admin/film_live/form_component.ex
@@ -816,8 +816,8 @@ defmodule MykonosBiennaleWeb.Admin.FilmLive.FormComponent do
       consume_uploaded_entries(socket, upload_key, fn %{path: path}, entry ->
         ext = Path.extname(entry.client_name)
         filename = "#{Ecto.UUID.generate()}#{ext}"
-        dest = Path.join(["priv", "static", "uploads", filename])
-        File.mkdir_p!(Path.dirname(dest))
+        dest = MykonosBiennale.Uploads.uploads_path(filename)
+        MykonosBiennale.Uploads.ensure_uploads_dir()
         File.cp!(path, dest)
         {:ok, %{path: filename, mime_type: entry.client_type, client_name: entry.client_name}}
       end)

--- a/lib/mykonos_biennale_web/live/admin/media_live/form_component.ex
+++ b/lib/mykonos_biennale_web/live/admin/media_live/form_component.ex
@@ -195,10 +195,9 @@ defmodule MykonosBiennaleWeb.Admin.MediaLive.FormComponent do
           # Generate unique filename
           ext = Path.extname(entry.client_name)
           filename = "#{Ecto.UUID.generate()}#{ext}"
-          dest = Path.join(["priv", "static", "uploads", filename])
+          dest = MykonosBiennale.Uploads.uploads_path(filename)
 
-          # Ensure uploads directory exists
-          File.mkdir_p!(Path.dirname(dest))
+          MykonosBiennale.Uploads.ensure_uploads_dir()
 
           # Copy file to destination
           File.cp!(path, dest)

--- a/lib/mykonos_biennale_web/live/admin/media_live/form_component.ex
+++ b/lib/mykonos_biennale_web/live/admin/media_live/form_component.ex
@@ -136,7 +136,7 @@ defmodule MykonosBiennaleWeb.Admin.MediaLive.FormComponent do
      |> allow_upload(:media_file,
        accept: ~w(.jpg .jpeg .png .gif .mp4 .webm .webp),
        max_entries: 1,
-       max_file_size: 10_000_000
+       max_file_size: 100_000_000
      )}
   end
 

--- a/lib/mykonos_biennale_web/live/admin/participant_live/form_component.ex
+++ b/lib/mykonos_biennale_web/live/admin/participant_live/form_component.ex
@@ -374,8 +374,8 @@ defmodule MykonosBiennaleWeb.Admin.ParticipantLive.FormComponent do
       consume_uploaded_entries(socket, :headshot, fn %{path: path}, entry ->
         ext = Path.extname(entry.client_name)
         filename = "#{Ecto.UUID.generate()}#{ext}"
-        dest = Path.join(["priv", "static", "uploads", filename])
-        File.mkdir_p!(Path.dirname(dest))
+        dest = MykonosBiennale.Uploads.uploads_path(filename)
+        MykonosBiennale.Uploads.ensure_uploads_dir()
         File.cp!(path, dest)
         {:ok, %{path: filename, mime_type: entry.client_type}}
       end)

--- a/priv/repo/migrations/20260515213216_add_template_to_entities.exs
+++ b/priv/repo/migrations/20260515213216_add_template_to_entities.exs
@@ -1,0 +1,9 @@
+defmodule MykonosBiennale.Repo.Migrations.AddTemplateToEntities do
+  use Ecto.Migration
+
+  def change do
+    alter table(:entities) do
+      add :template, :string, default: "default", null: false
+    end
+  end
+end

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Backup the Mykonos Biennale development database
+# Usage: ./scripts/backup_db.sh [label]
+
+set -e
+
+DB="mykonos_biennale_dev.db"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BACKUPS_DIR="$PROJECT_DIR/backups"
+
+mkdir -p "$BACKUPS_DIR"
+
+LABEL="${1:-$(date +%Y%m%d_%H%M%S)}"
+BACKUP_FILE="$BACKUPS_DIR/${DB%.db}_${LABEL}.db"
+
+if [ ! -f "$PROJECT_DIR/$DB" ]; then
+  echo "ERROR: Database not found at $PROJECT_DIR/$DB"
+  exit 1
+fi
+
+# Checkpoint WAL on the live DB first, then copy
+sqlite3 "$PROJECT_DIR/$DB" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true
+cp "$PROJECT_DIR/$DB" "$BACKUP_FILE"
+
+# Count records for verification
+ENTITIES=$(sqlite3 "$BACKUP_FILE" "SELECT COUNT(*) FROM entities;")
+RELATIONSHIPS=$(sqlite3 "$BACKUP_FILE" "SELECT COUNT(*) FROM relationships;")
+MEDIA=$(sqlite3 "$BACKUP_FILE" "SELECT COUNT(*) FROM media;")
+
+echo "Backup created: $BACKUP_FILE"
+echo "  Entities: $ENTITIES"
+echo "  Relationships: $RELATIONSHIPS"
+echo "  Media: $MEDIA"

--- a/scripts/sync_from_prod.sh
+++ b/scripts/sync_from_prod.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+APP_NAME="mykonos-biennale"
+
+echo "=== Sync production data to local dev ==="
+echo ""
+echo "This script dumps the production database, downloads it, and restores"
+echo "it into your local dev database."
+echo ""
+
+# Step 1: Dump production DB to JSON on the remote machine
+echo "Dumping production database..."
+fly ssh console -C "cd /app && mix app.dump --output /tmp/data_dump.json" -a "$APP_NAME"
+
+# Step 2: Download the dump file
+echo "Downloading dump file..."
+fly sftp get /tmp/data_dump.json priv/repo/data_dump_from_prod.json -a "$APP_NAME"
+
+# Step 3: Clean up the remote dump
+fly ssh console -C "rm /tmp/data_dump.json" -a "$APP_NAME"
+
+# Step 4: Backup local DB
+LOCAL_DB="mykonos_biennale_dev.db"
+if [ -f "$LOCAL_DB" ]; then
+  BACKUP="${LOCAL_DB}.backup.$(date +%Y%m%d%H%M%S)"
+  echo "Backing up local DB to $BACKUP..."
+  cp "$LOCAL_DB" "$BACKUP"
+fi
+
+# Step 5: Restore into local DB
+echo "Restoring production data into local dev database..."
+mix app.restore --input priv/repo/data_dump_from_prod.json
+
+# Step 6: Clean up
+rm -f priv/repo/data_dump_from_prod.json
+
+echo ""
+echo "=== Done! ==="
+echo "Local dev database now contains production data."
+if [ -n "$BACKUP" ]; then
+  echo "Backup saved to: $BACKUP"
+  echo "To rollback: cp $BACKUP $LOCAL_DB"
+fi

--- a/scripts/sync_uploads_to_fly.sh
+++ b/scripts/sync_uploads_to_fly.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+echo "=== Syncing uploads to Fly.io ==="
+echo ""
+echo "This script uploads your local uploads to the Fly.io persistent volume."
+echo "It creates a tarball locally, copies it to the machine, and extracts it there."
+echo ""
+
+# Create tarball of uploads (excluding hidden files like .DS_Store)
+echo "Creating tarball of priv/static/uploads/..."
+tar czf /tmp/uploads.tar.gz -C priv/static uploads/ --exclude='.DS_Store'
+
+TARBALL_SIZE=$(du -sh /tmp/uploads.tar.gz | cut -f1)
+echo "Tarball size: $TARBALL_SIZE"
+echo ""
+
+# Upload to the machine
+echo "Uploading tarball to Fly.io machine..."
+fly sftp put /tmp/uploads.tar.gz /tmp/uploads.tar.gz
+
+# Extract on the remote machine
+echo "Extracting tarball on remote machine..."
+fly ssh console -C "mkdir -p /data/uploads && tar xzf /tmp/uploads.tar.gz -C /data/ && rm /tmp/uploads.tar.gz"
+
+# Clean up local tarball
+rm /tmp/uploads.tar.gz
+
+echo ""
+echo "=== Done! ==="
+echo "Uploads are now in /data/uploads/ on the Fly.io volume."
+echo "Verify with: fly ssh console -C 'ls /data/uploads/ | head'"


### PR DESCRIPTION
Add data dump/restore tasks, Fly.io deployment config, and upload path centralization

 - closed #110 Add mix app.dump and mix app.restore tasks for portable JSON-based database export/import (supports both SQLite and Postgres)
 - closed #111 Add scripts/sync_from_prod.sh to pull production data into local dev
 - closed #112 Configure Fly.io persistent volume for SQLite DB and file uploads (fly.toml mounts, DATABASE_PATH env, runtime.exs, Dockerfile symlink)
 - closed #113 Centralize upload path config in MykonosBiennale.Uploads module
 - closed #114 Add second Plug.Static in endpoint for /uploads serving in production
 - closed #115 Add release.ex for running migrations in production
 - closed #116 Update all admin form components and import workers to use Uploads module
 - closed #117 Update .gitignore for uploads dir and SQLite files
 - closed #118 Add sync_uploads_to_fly.sh for uploading media to production volume