### PR TITLE
Fixed. The root cause was MediaSlug using base62 encoding (mixed case…

### DIFF
--- a/lib/mykonos_biennale/media_slug.ex
+++ b/lib/mykonos_biennale/media_slug.ex
@@ -55,16 +55,16 @@ defmodule MykonosBiennale.MediaSlug do
   defp ensure_nonempty(""), do: "media"
   defp ensure_nonempty(s), do: s
 
-  @chars ~c"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  @chars ~c"0123456789abcdefghijklmnopqrstuvwxyz"
 
   def encode_id(id) when is_integer(id) and id > 0 do
-    id |> encode_base62([]) |> List.to_string()
+    id |> encode_base36([]) |> List.to_string()
   end
 
-  defp encode_base62(0, acc), do: [Enum.at(@chars, 0) | acc]
+  defp encode_base36(0, acc), do: [Enum.at(@chars, 0) | acc]
 
-  defp encode_base62(id, acc) do
-    encode_base62(div(id, 62), [Enum.at(@chars, rem(id, 62)) | acc])
+  defp encode_base36(id, acc) do
+    encode_base36(div(id, 36), [Enum.at(@chars, rem(id, 36)) | acc])
   end
 
   def decode_id(encoded) when is_binary(encoded) do

--- a/lib/mykonos_biennale/reimport_artworks.ex
+++ b/lib/mykonos_biennale/reimport_artworks.ex
@@ -1,0 +1,405 @@
+defmodule MykonosBiennale.ReimportArtworks do
+  @moduledoc """
+  Reimports artworks from the festival export, grouping duplicates by
+  (title_slug, year, project_slug, artist_name). Relinks existing media
+  records by matching original_name to the export file paths.
+  """
+
+  import Ecto.Query, warn: false
+  alias MykonosBiennale.Repo
+  alias MykonosBiennale.Content
+  alias MykonosBiennale.Content.{Entity, Media, EntityMedia, Relationship, RelationshipType}
+
+  @records_path "exports/festival/records.json"
+
+  def load_export do
+    path = Path.join(File.cwd!(), @records_path)
+    {:ok, raw} = File.read(path)
+    Jason.decode!(raw)
+  end
+
+  def build_groups do
+    records = load_export()
+
+    arts = Enum.filter(records, &(&1["model"] == "festival.art"))
+    projects = Enum.filter(records, &(&1["model"] == "festival.project"))
+    projectseasons = Enum.filter(records, &(&1["model"] == "festival.projectseason"))
+    artists = Enum.filter(records, &(&1["model"] == "festival.artist"))
+    festivals = Enum.filter(records, &(&1["model"] == "festival.festival"))
+
+    project_map = Enum.into(projects, %{}, &{&1["pk"], &1})
+    projectseason_map = Enum.into(projectseasons, %{}, &{&1["pk"], &1})
+    artist_map = Enum.into(artists, %{}, &{&1["pk"], &1})
+    festival_map = Enum.into(festivals, %{}, &{&1["pk"], &1})
+
+    groups =
+      Enum.group_by(arts, fn art ->
+        title = art["fields"]["title"] || ""
+        title_slug = slugify(title)
+
+        project_pk = get_in(art, ["foreign_keys", "project", "pk"])
+        project = Map.get(project_map, project_pk)
+        project_slug = project && project["fields"]["slug"] || ""
+
+        project_x_pk = get_in(art, ["foreign_keys", "project_x", "pk"])
+        ps = Map.get(projectseason_map, project_x_pk)
+        fest_pk = ps && get_in(ps, ["foreign_keys", "festival", "pk"])
+        festival = fest_pk && Map.get(festival_map, fest_pk)
+        year = festival && to_string(festival["fields"]["year"]) || ""
+
+        artist_pk = get_in(art, ["foreign_keys", "artist", "pk"])
+        artist = Map.get(artist_map, artist_pk)
+        artist_name = artist && artist["fields"]["name"] || ""
+
+        biennale_title = festival && festival["fields"]["title"] || ""
+
+        {title_slug, year, project_slug, artist_name}
+      end)
+
+    groups
+    |> Enum.map(fn {{title_slug, year, project_slug, artist_name} = key, items} ->
+      sorted = Enum.sort_by(items, & &1["pk"])
+      first = hd(sorted)
+
+      all_files =
+        items
+        |> Enum.flat_map(fn art ->
+          (art["files"] || [])
+          |> Enum.map(fn f -> Map.get(f, "path", "") |> String.split("/") |> List.last() end)
+          |> Enum.reject(&(&1 in ["", nil]))
+        end)
+        |> Enum.uniq()
+
+      %{
+        key: key,
+        title: first["fields"]["title"] || "Untitled",
+        title_slug: title_slug,
+        year: year,
+        project_slug: project_slug,
+        artist_name: artist_name,
+        biennale_title: get_biennale_title(items, project_map, projectseason_map, festival_map),
+        count: length(items),
+        pks: Enum.map(items, & &1["pk"]),
+        file_names: all_files,
+        description: best_description(items),
+        photo_url: first["fields"]["photo"],
+        art_type: infer_art_type(project_slug),
+        leader: Enum.any?(items, & &1["fields"]["leader"] == true)
+      }
+    end)
+    |> Enum.sort_by(fn g -> {g.artist_name, g.year, g.title} end)
+  end
+
+  defp get_biennale_title(items, project_map, ps_map, fest_map) do
+    art = hd(items)
+    project_pk = get_in(art, ["foreign_keys", "project", "pk"])
+    project = Map.get(project_map, project_pk)
+    fest_pk = project && get_in(project, ["foreign_keys", "festival", "pk"])
+    festival = fest_pk && Map.get(fest_map, fest_pk)
+    festival && festival["fields"]["title"] || ""
+  end
+
+  defp best_description(items) do
+    Enum.find_value(items, fn art ->
+      d = art["fields"]["description"]
+      if d && String.trim(d) != "", do: String.trim(d), else: nil
+    end) || ""
+  end
+
+  @art_type_inference %{
+    "dramatic-nights" => "performance",
+    "video-graffiti" => "video",
+    "film-festival" => "film",
+    "manilapdfmpeg" => "film",
+    "kite-festival" => "artwork",
+    "treasure-hunt" => "artwork",
+    "archaeological-museum" => "artwork",
+    "a-night-of-philosophy" => "event",
+    "trans-allegoria" => "artwork",
+    "andromeda" => "artwork",
+    "ocean-masks" => "artwork",
+    "metamorphosis" => "artwork",
+    "art-spell" => "artwork",
+    "the-wind-igloo-project" => "artwork",
+    "mirror-mirror" => "artwork",
+    "birth-of-a-bubble" => "artwork",
+    "epivatikos-stathmos" => "artwork",
+    "idols-and-ideas" => "artwork",
+    "flags" => "artwork",
+    "the-greek-caribbean-cultural-exchange" => "artwork",
+    "performance" => "performance",
+    "the-house-on-matoyianni-street" => "artwork",
+    "garden-of-mysteries" => "artwork",
+    "animation" => "film",
+    "urban" => "artwork",
+    "antidote" => "artwork"
+  }
+
+  defp infer_art_type(slug) do
+    Map.get(@art_type_inference, slug, "artwork")
+  end
+
+  def build_media_index do
+    Repo.all(
+      from m in Media,
+        where: m.source_type == "upload" and like(m.original_name, "mykonos-biennale-%"),
+        select: {m.original_name, m.id, m.source_path}
+    )
+    |> Enum.group_by(&elem(&1, 0))
+    |> Enum.map(fn {name, rows} ->
+      {^name, id, path} = Enum.min_by(rows, &elem(&1, 1))
+      {name, id, path}
+    end)
+    |> Enum.into(%{}, fn {name, id, path} -> {name, {id, path}} end)
+  end
+
+  def delete_existing_artworks do
+    artwork_ids =
+      Repo.all(from e in Entity, where: e.type == "artwork", select: e.id)
+
+    if artwork_ids != [] do
+      ae_rt = Repo.one(from rt in RelationshipType, where: rt.slug == "artwork_event")
+      ap_rt = Repo.one(from rt in RelationshipType, where: rt.slug == "artwork_participant")
+
+      if ae_rt && ap_rt do
+        Repo.delete_all(
+          from r in Relationship,
+            where:
+              (r.subject_id in ^artwork_ids and r.relationship_type_id == ^ae_rt.id) or
+                (r.subject_id in ^artwork_ids and r.relationship_type_id == ^ap_rt.id)
+        )
+      end
+
+      Repo.delete_all(from em in EntityMedia, where: em.entity_id in ^artwork_ids)
+      Repo.delete_all(from e in Entity, where: e.id in ^artwork_ids)
+    end
+
+    {length(artwork_ids), artwork_ids}
+  end
+
+  def import_groups(groups) do
+    media_index = build_media_index()
+
+    artist_pk_to_id = build_artist_pk_to_participant_id()
+    fest_to_biennale = build_festival_pk_to_biennale_id()
+    proj_pk_to_event_id = build_project_pk_to_event_id(fest_to_biennale)
+
+    results =
+      for group <- groups do
+        attrs = %{
+          title: group.title,
+          description: group.description,
+          type: group.art_type,
+          date: group.year,
+          visible: true
+        }
+
+        case Content.create_artwork(attrs) do
+          {:ok, artwork} ->
+            updated_fields =
+              artwork.fields
+              |> Map.put("import_pks", Enum.map(group.pks, &to_string/1))
+              |> Map.put("import_model", "festival.art")
+              |> Map.put("leader", group.leader)
+              |> Map.put("import_photo_url", group.photo_url)
+              |> Map.put("reimported", true)
+
+            artwork
+            |> Ecto.Changeset.change(fields: updated_fields)
+            |> Repo.update!()
+
+            attach_participant(artwork, group, artist_pk_to_id)
+            attach_event(artwork, group, proj_pk_to_event_id)
+            link_media(artwork, group, media_index)
+
+            {:ok, artwork}
+
+          {:error, cs} ->
+            {:error, cs}
+        end
+      end
+
+    created = Enum.count(results, &match?({:ok, _}, &1))
+    errors = Enum.count(results, &match?({:error, _}, &1))
+    {created, errors}
+  end
+
+  defp link_media(artwork, group, media_index) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    rows =
+      group.file_names
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {filename, idx} ->
+        case Map.get(media_index, filename) do
+          nil ->
+            []
+
+          {media_id, _path} ->
+            [[entity_id: artwork.id, media_id: media_id, position: idx, metadata: %{}, inserted_at: now, updated_at: now]]
+        end
+      end)
+
+    if rows != [] do
+      Repo.insert_all(EntityMedia, rows)
+    end
+
+    length(rows)
+  end
+
+  defp attach_participant(artwork, group, artist_pk_to_id) do
+    records = load_export()
+    arts = Enum.filter(records, &(&1["model"] == "festival.art" and &1["pk"] in group.pks))
+
+    artist_pks =
+      arts
+      |> Enum.map(&get_in(&1, ["foreign_keys", "artist", "pk"]))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    for artist_pk <- artist_pks do
+      case Map.get(artist_pk_to_id, artist_pk) do
+        nil ->
+          :ok
+
+        participant_id ->
+          participant = Content.get_participant!(participant_id)
+
+          case Content.list_artwork_linked_participants(artwork)
+               |> Enum.find(&(&1.id == participant_id)) do
+            nil ->
+              Content.attach_participant_to_artwork(artwork, participant, "creator")
+
+            _ ->
+              :ok
+          end
+      end
+    end
+  end
+
+  defp attach_event(artwork, group, proj_pk_to_event_id) do
+    records = load_export()
+    arts = Enum.filter(records, &(&1["model"] == "festival.art" and &1["pk"] in group.pks))
+
+    project_pks =
+      arts
+      |> Enum.map(&get_in(&1, ["foreign_keys", "project", "pk"]))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    for project_pk <- project_pks do
+      case Map.get(proj_pk_to_event_id, project_pk) do
+        nil ->
+          :ok
+
+        event_id ->
+          event = Content.get_event!(event_id)
+
+          case Content.list_artwork_linked_events(artwork)
+               |> Enum.find(&(&1.id == event_id)) do
+            nil ->
+              Content.attach_event_to_artwork(artwork, event)
+
+            _ ->
+              :ok
+          end
+      end
+    end
+  end
+
+  defp build_artist_pk_to_participant_id do
+    Repo.all(
+      from e in Entity,
+        where:
+          e.type == "participant" and
+            fragment("? ->> 'import_model'", e.fields) == "festival.artist",
+        select: {fragment("CAST(? ->> 'import_pk' AS INTEGER)", e.fields), e.id}
+    )
+    |> Enum.into(%{})
+  end
+
+  defp build_festival_pk_to_biennale_id do
+    Repo.all(
+      from e in Entity,
+        where:
+          e.type == "biennale" and
+            fragment("? ->> 'import_model'", e.fields) == "festival.festival",
+        select: {fragment("CAST(? ->> 'import_pk' AS INTEGER)", e.fields), e.id}
+    )
+    |> Enum.into(%{})
+  end
+
+  defp build_project_pk_to_event_id(fest_to_biennale) do
+    events =
+      Repo.all(
+        from e in Entity,
+          where:
+            e.type == "event" and fragment("? ->> 'import_key' IS NOT NULL", e.fields),
+          select: {fragment("? ->> 'import_key'", e.fields), e.id}
+      )
+      |> Enum.into(%{})
+
+    records = load_export()
+    projects = Enum.filter(records, &(&1["model"] == "festival.project"))
+
+    slug_to_project = build_project_slug_to_id()
+
+    projects
+    |> Enum.reduce(%{}, fn proj, acc ->
+      fest_pk = get_in(proj["foreign_keys"], ["festival", "pk"])
+      biennale_id = Map.get(fest_to_biennale, fest_pk)
+
+      proj_slug =
+        normalize_slug(proj["fields"]["slug"])
+
+      project_entity_id = Map.get(slug_to_project, proj_slug)
+      proj_pk = proj["pk"]
+
+      if biennale_id && project_entity_id do
+        import_key = "#{biennale_id}-#{project_entity_id}"
+        event_id = Map.get(events, import_key)
+
+        if event_id do
+          Map.put(acc, proj_pk, event_id)
+        else
+          acc
+        end
+      else
+        acc
+      end
+    end)
+  end
+
+  defp build_project_slug_to_id do
+    Repo.all(
+      from e in Entity,
+        where:
+          e.type == "project" and
+            fragment("? ->> 'import_slug' IS NOT NULL", e.fields),
+        select: {fragment("? ->> 'import_slug'", e.fields), e.id}
+    )
+    |> Enum.into(%{})
+  end
+
+  @slug_normalizations %{
+    "antidode" => "treasure-hunt",
+    "antidote" => "treasure-hunt",
+    "archeological-museum" => "archaeological-museum",
+    "lavra" => "flags"
+  }
+
+  defp normalize_slug(slug) do
+    Map.get(@slug_normalizations, slug, slug)
+  end
+
+  defp slugify(nil), do: ""
+
+  defp slugify(title) when is_binary(title) do
+    title
+    |> String.downcase()
+    |> String.replace(~r/[^\w\s-]/u, " ")
+    |> String.replace(~r/[-_]+/u, " ")
+    |> String.replace(~r/\s+/, "-")
+    |> String.trim("-")
+  end
+end

--- a/lib/mykonos_biennale/workers/media_process.ex
+++ b/lib/mykonos_biennale/workers/media_process.ex
@@ -48,6 +48,14 @@ defmodule MykonosBiennale.Workers.MediaProcess do
     end
   end
 
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"kind" => "rotate", "media_id" => id, "degrees" => degrees}}) do
+    case Repo.get(Media, id) do
+      nil -> :ok
+      media -> rotate_media(media, degrees)
+    end
+  end
+
   def perform(%Oban.Job{args: %{"kind" => "all", "media_id" => id}}) do
     case Repo.get(Media, id) do
       nil ->
@@ -186,6 +194,47 @@ defmodule MykonosBiennale.Workers.MediaProcess do
     :ok
   end
 
+  defp rotate_media(%Media{slug: slug, source_type: "upload", source_path: path}, degrees)
+       when is_binary(path) and is_binary(slug) do
+    unless image_ext?(path) do
+      {:ok, :skipped}
+    else
+      original_path = MykonosBiennale.Uploads.uploads_path(path)
+
+      if File.exists?(original_path) do
+        cmd = System.find_executable("magick") || "convert"
+
+        args = [
+          original_path,
+          "-rotate",
+          to_string(degrees),
+          original_path
+        ]
+
+        case System.cmd(cmd, args, stderr_to_stdout: true) do
+          {_, 0} ->
+            Thumbnail.invalidate_slug_cache(slug)
+            generate_webp_sizes(%Media{slug: slug, source_type: "upload", source_path: path})
+            enqueue_avif_and_press(id_for_slug(slug))
+            {:ok, :rotated}
+
+          {error, _code} ->
+            require Logger
+            Logger.warning("Rotation failed for #{original_path}: #{error}")
+            {:error, :rotate_failed}
+        end
+      else
+        {:ok, :no_source}
+      end
+    end
+  end
+
+  defp rotate_media(_, _), do: {:ok, :skipped}
+
+  defp id_for_slug(slug) do
+    Repo.one(from m in Media, where: m.slug == ^slug, select: m.id)
+  end
+
   defp image_ext?(filename) do
     ext = filename |> Path.extname() |> String.downcase()
     ext in [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".tif"]
@@ -205,5 +254,11 @@ defmodule MykonosBiennale.Workers.MediaProcess do
 
   def enqueue_press(media_id) when is_integer(media_id) do
     %{kind: "press", media_id: media_id} |> __MODULE__.new() |> Oban.insert()
+  end
+
+  def enqueue_rotate(media_id, degrees) when is_integer(media_id) do
+    %{kind: "rotate", media_id: media_id, degrees: degrees}
+    |> __MODULE__.new()
+    |> Oban.insert()
   end
 end

--- a/lib/mykonos_biennale_web/controllers/artwork_controller.ex
+++ b/lib/mykonos_biennale_web/controllers/artwork_controller.ex
@@ -1,0 +1,108 @@
+defmodule MykonosBiennaleWeb.ArtworkController do
+  use MykonosBiennaleWeb, :controller
+
+  import Ecto.Query, warn: false
+
+  alias MykonosBiennale.Repo
+  alias MykonosBiennale.Content
+  alias MykonosBiennale.Content.{Entity, Relationship, RelationshipType}
+  alias MykonosBiennaleWeb.ArtworkHTML
+
+  def show(conn, %{"id" => id}) do
+    case Repo.get(Entity, id) do
+      %Entity{type: "artwork", visible: true} = artwork ->
+        render_artwork(conn, artwork)
+
+      _ ->
+        not_found(conn)
+    end
+  end
+
+  def show_by_slug(conn, %{"slug" => slug}) do
+    case Repo.get_by(Entity, slug: slug, type: "artwork") do
+      %Entity{visible: true} = artwork ->
+        render_artwork(conn, artwork)
+
+      _ ->
+        not_found(conn)
+    end
+  end
+
+  defp render_artwork(conn, artwork) do
+    media = Content.list_media_for_entity(artwork)
+    participants = list_linked_participants(artwork)
+    events = list_linked_events(artwork)
+
+    conn
+    |> assign(:artwork, artwork)
+    |> assign(:media, media)
+    |> assign(:participants, participants)
+    |> assign(:events, events)
+    |> assign(:page_title, "#{artwork.fields["title"] || "Untitled"} — Mykonos Biennale")
+    |> render(:show)
+  end
+
+  defp list_linked_participants(artwork) do
+    rt = Repo.get_by(RelationshipType, slug: "artwork_participant")
+
+    if rt do
+      Repo.all(
+        from r in Relationship,
+          where: r.subject_id == ^artwork.id and r.relationship_type_id == ^rt.id,
+          preload: [:object]
+      )
+      |> Enum.map(& &1.object)
+    else
+      []
+    end
+  end
+
+  defp list_linked_events(artwork) do
+    rt = Repo.get_by(RelationshipType, slug: "artwork_event")
+
+    if rt do
+      Repo.all(
+        from r in Relationship,
+          where: r.subject_id == ^artwork.id and r.relationship_type_id == ^rt.id,
+          preload: [:object]
+      )
+      |> Enum.map(fn rel ->
+        event = rel.object
+        %{
+          id: event.id,
+          title: event.fields["title"],
+          type: event.fields["type"],
+          date: event.fields["date"],
+          slug: event.slug,
+          biennale: biennale_for_event(event)
+        }
+      end)
+    else
+      []
+    end
+  end
+
+  defp biennale_for_event(event) do
+    rt = Repo.get_by(RelationshipType, slug: "biennale_event")
+
+    if rt do
+      case Repo.one(
+             from r in Relationship,
+               where: r.subject_id == ^event.id and r.relationship_type_id == ^rt.id,
+               preload: [:object]
+           ) do
+        nil -> nil
+        rel -> rel.object
+      end
+    else
+      nil
+    end
+  end
+
+  defp not_found(conn) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(MykonosBiennaleWeb.ErrorHTML)
+    |> render(:"404")
+  end
+end

--- a/lib/mykonos_biennale_web/controllers/artwork_html.ex
+++ b/lib/mykonos_biennale_web/controllers/artwork_html.ex
@@ -1,0 +1,29 @@
+defmodule MykonosBiennaleWeb.ArtworkHTML do
+  use MykonosBiennaleWeb, :html
+
+  alias MykonosBiennale.Content.Entity
+
+  embed_templates "artwork_html/*"
+
+  def media_url(media, opts \\ [])
+  def media_url(media, opts), do: MykonosBiennale.Uploads.media_url(media, opts)
+
+  defp field(%Entity{fields: fields}, key, default \\ nil) when is_map(fields) do
+    Map.get(fields, to_string(key), Map.get(fields, key, default))
+  end
+
+  defp field(_, _key, default), do: default
+
+  defp participant_name(%Entity{fields: %{"name" => name}}) when is_binary(name) and name != "",
+    do: name
+
+  defp participant_name(%Entity{fields: %{"first_name" => first, "last_name" => last}}),
+    do: String.trim("#{first || ""} #{last || ""}")
+
+  defp participant_name(_), do: "Unknown"
+
+  defp dimensions(nil, nil), do: nil
+  defp dimensions(nil, h), do: "#{h} cm"
+  defp dimensions(w, nil), do: "#{w} cm"
+  defp dimensions(w, h), do: "#{w} × #{h} cm"
+end

--- a/lib/mykonos_biennale_web/controllers/artwork_html/show.html.heex
+++ b/lib/mykonos_biennale_web/controllers/artwork_html/show.html.heex
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{@page_title}</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/photoswipe@5.4.3/dist/photoswipe.min.css" />
+  <style>
+    body { background: #0a0a0a; }
+    .pswp { --pswp-bg: #000; }
+  </style>
+</head>
+<body class="bg-neutral-950 text-neutral-200 min-h-screen">
+  <nav class="border-b border-neutral-800 px-6 py-4">
+    <div class="max-w-5xl mx-auto flex items-center justify-between">
+      <a href="/" class="text-lg font-semibold text-white tracking-wide">MYKONOS BIENNALE</a>
+      <div class="flex gap-6 text-sm">
+        <a href="/archive" class="text-neutral-400 hover:text-white transition-colors">Archive</a>
+        <a href="/program" class="text-neutral-400 hover:text-white transition-colors">Program</a>
+        <a href="/about" class="text-neutral-400 hover:text-white transition-colors">About</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="max-w-5xl mx-auto px-6 py-12">
+    <article>
+      <%!-- Artist --%>
+      <div :if={@participants != []} class="mb-2">
+        <%= for p <- @participants do %>
+          <span class="text-lg text-neutral-400">{participant_name(p)}</span>
+        <% end %>
+      </div>
+
+      <%!-- Title --%>
+      <h1 class="text-4xl md:text-5xl font-light text-white mb-2">
+        {field(@artwork, "title", "Untitled")}
+      </h1>
+
+      <%!-- Year --%>
+      <p :if={field(@artwork, "date")} class="text-lg text-neutral-500 mb-4">
+        {field(@artwork, "date")}
+      </p>
+
+      <%!-- Size, Material --%>
+      <div :if={field(@artwork, "size") || field(@artwork, "medium")} class="text-sm text-neutral-500 mb-6">
+        <span :if={field(@artwork, "medium")}>{field(@artwork, "medium")}</span>
+        <span :if={field(@artwork, "medium") && field(@artwork, "size")}>, </span>
+        <span :if={field(@artwork, "size")}>{field(@artwork, "size")}</span>
+      </div>
+
+      <%!-- Gallery --%>
+      <div :if={@media != []} class="mb-8">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <%= for {m, idx} <- Enum.with_index(@media) do %>
+            <div class={"overflow-hidden rounded-lg bg-neutral-900 " <> if(idx == 0, do: "md:col-span-2", else: "")}>
+              <a
+                href={media_url(m, size: "hero")}
+                data-pswp-width="1920"
+                data-pswp-height="1080"
+                target="_blank"
+                class="block"
+              >
+                <img
+                  src={media_url(m, size: "card")}
+                  alt={m.alt_text || m.caption || field(@artwork, "title")}
+                  class="w-full h-auto object-contain"
+                  loading={if idx == 0, do: "eager", else: "lazy"}
+                />
+              </a>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <%!-- Description / Statement --%>
+      <div :if={field(@artwork, "description")} class="prose prose-invert prose-neutral max-w-2xl mt-8">
+        <p class="text-neutral-400 leading-relaxed whitespace-pre-line">
+          {field(@artwork, "description")}
+        </p>
+      </div>
+
+      <%!-- Events / Projects --%>
+      <div :if={@events != []} class="mt-12 border-t border-neutral-800 pt-8">
+        <h2 class="text-xs uppercase tracking-widest text-neutral-600 mb-4">Exhibited at</h2>
+        <div class="flex flex-wrap gap-3">
+          <%= for event <- @events do %>
+            <div class="text-sm">
+              <span class="text-neutral-300">{event.title}</span>
+              <span :if={event.date} class="text-neutral-600 ml-2">{event.date}</span>
+              <%= if event.biennale do %>
+                <span class="text-neutral-600 ml-2">
+                  <a href={"/biennale/#{event.biennale.slug}"} class="hover:text-neutral-400 transition-colors">
+                    Mykonos Biennale {field(event.biennale, "year")}
+                  </a>
+                </span>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </article>
+  </main>
+
+  <footer class="border-t border-neutral-800 px-6 py-6 mt-12">
+    <div class="max-w-5xl mx-auto text-sm text-neutral-600">
+      Mykonos Biennale
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/photoswipe@5.4.3/dist/photoswipe-lightbox.umd.min.js"></script>
+  <script>
+    const lightbox = new PhotoSwipeLightbox({
+      gallery: 'main',
+      children: 'a[data-pswp-width]',
+      pswpModule: () => import('https://cdn.jsdelivr.net/npm/photoswipe@5.4.3/dist/photoswipe.esm.js'),
+    });
+    lightbox.init();
+  </script>
+</body>
+</html>

--- a/lib/mykonos_biennale_web/live/admin/artwork_live/form_component.ex
+++ b/lib/mykonos_biennale_web/live/admin/artwork_live/form_component.ex
@@ -41,6 +41,16 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.FormComponent do
     <div data-theme="light" class="bg-white rounded-xl [&_.label]:text-gray-900 [&_h1]:text-gray-900">
       <.header>
         {@title}
+        <:actions>
+          <.link
+            :if={@artwork.id}
+            href={"/art/#{@artwork.id}"}
+            target="_blank"
+            class="text-sm text-blue-600 hover:text-blue-700"
+          >
+            See on Site
+          </.link>
+        </:actions>
       </.header>
 
       <.form

--- a/lib/mykonos_biennale_web/live/admin/artwork_live/merge.ex
+++ b/lib/mykonos_biennale_web/live/admin/artwork_live/merge.ex
@@ -5,80 +5,211 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.Merge do
 
   alias MykonosBiennale.Repo
   alias MykonosBiennale.Content
-  alias MykonosBiennale.Content.{Entity, Relationship, RelationshipType, EntityMedia}
+  alias MykonosBiennale.Content.{Entity, Media, Relationship, RelationshipType, EntityMedia}
 
   @impl true
   def mount(_params, _session, socket) do
     socket =
       socket
       |> assign(:duplicate_groups, [])
+      |> assign(:all_groups, [])
+      |> assign(:groups_loaded, false)
       |> assign(:selected_ids, MapSet.new())
-      |> assign(:group_mode, "broad")
+      |> assign(:group_mode, "narrow")
       |> assign(:page, 1)
       |> assign(:per_page, 20)
       |> assign(:total_pages, 1)
+      |> assign(:all_groups_count, 0)
       |> assign(:merged_count, 0)
+      |> assign(:loading, false)
 
     {:ok, socket}
   end
 
   @impl true
-  def handle_params(_params, _uri, socket) do
-    duplicate_groups = load_duplicate_groups(socket.assigns.group_mode)
-    total_pages = max(1, ceil(length(duplicate_groups) / socket.assigns.per_page))
-    {:noreply, assign(socket, duplicate_groups: duplicate_groups, total_pages: total_pages)}
+  def handle_params(params, _uri, socket) do
+    page = String.to_integer(params["page"] || "1")
+
+    {all_groups, socket} =
+      if socket.assigns.groups_loaded do
+        {socket.assigns.all_groups, socket}
+      else
+        socket = assign(socket, :loading, true)
+        groups = load_duplicate_groups(socket.assigns.group_mode)
+        socket = assign(socket, :loading, false)
+        {groups, socket}
+      end
+
+    total_pages = max(1, ceil(length(all_groups) / socket.assigns.per_page))
+    page = min(page, total_pages)
+    offset = (page - 1) * socket.assigns.per_page
+    page_groups = Enum.slice(all_groups, offset, socket.assigns.per_page)
+
+    {:noreply,
+     socket
+     |> assign(:all_groups, all_groups)
+     |> assign(:duplicate_groups, page_groups)
+     |> assign(:all_groups_count, length(all_groups))
+     |> assign(:page, page)
+     |> assign(:total_pages, total_pages)
+     |> assign(:groups_loaded, true)}
+
+  rescue
+    _ ->
+      {:noreply, assign(socket, :loading, false)}
   end
 
   @impl true
   def handle_event("set_group_mode", %{"mode" => mode}, socket)
       when mode in ["broad", "narrow"] do
-    duplicate_groups = load_duplicate_groups(mode)
-
     {:noreply,
      socket
      |> assign(:group_mode, mode)
+     |> assign(:groups_loaded, false)
      |> assign(:selected_ids, MapSet.new())
-     |> assign(:duplicate_groups, duplicate_groups)}
+     |> push_patch(to: "/admin/artworks/merge?page=1")}
+  end
+
+  def handle_event("toggle_select", %{"id" => id_str}, socket) do
+    id = String.to_integer(id_str)
+    selected = socket.assigns.selected_ids
+
+    new_selected =
+      if MapSet.member?(selected, id) do
+        MapSet.delete(selected, id)
+      else
+        MapSet.put(selected, id)
+      end
+
+    {:noreply, assign(socket, :selected_ids, new_selected)}
+  end
+
+  def handle_event("merge_selected", _, socket) do
+    groups = socket.assigns.duplicate_groups
+    selected = socket.assigns.selected_ids
+
+    {merged, survivor_ids} =
+      Enum.reduce(groups, {0, []}, fn group, {count, survivors} ->
+        group_ids = Enum.map(group.entries, & &1.artwork.id)
+        selected_in_group = group_ids |> Enum.filter(&MapSet.member?(selected, &1))
+
+        if length(group.entries) >= 2 and length(selected_in_group) > 0 do
+          survivor_id = hd(selected_in_group)
+          to_merge = Enum.reject(group.entries, fn e -> e.artwork.id == survivor_id end)
+          survivor_entry = Enum.find(group.entries, &(&1.artwork.id == survivor_id))
+          merge_artworks!(survivor_entry, to_merge)
+          {count + 1, [survivor_id | survivors]}
+        else
+          {count, survivors}
+        end
+      end)
+
+    enqueue_reindex(survivor_ids)
+
+    {:noreply,
+     socket
+     |> assign(:merged_count, merged)
+     |> assign(:selected_ids, MapSet.new())
+     |> assign(:groups_loaded, false)
+     |> push_patch(to: "/admin/artworks/merge?page=#{socket.assigns.page}")}
+  end
+
+  def handle_event("merge_all", _, socket) do
+    all_groups = load_duplicate_groups(socket.assigns.group_mode)
+
+    {merged, survivor_ids} =
+      Enum.reduce(all_groups, {0, []}, fn group, {count, survivors} ->
+        if length(group.entries) < 2 do
+          {count, survivors}
+        else
+          sorted_entries = Enum.sort_by(group.entries, & &1.artwork.id)
+          survivor_entry = hd(sorted_entries)
+          to_merge = tl(sorted_entries)
+          merge_artworks!(survivor_entry, to_merge)
+          {count + 1, [survivor_entry.artwork.id | survivors]}
+        end
+      end)
+
+    enqueue_reindex(survivor_ids)
+
+    {:noreply,
+     socket
+     |> assign(:merged_count, merged)
+     |> assign(:selected_ids, MapSet.new())
+     |> assign(:groups_loaded, false)
+     |> push_patch(to: "/admin/artworks/merge?page=1")}
+  end
+
+  defp enqueue_reindex([]), do: :ok
+
+  defp enqueue_reindex(survivor_ids) do
+    survivor_ids
+    |> Enum.uniq()
+    |> Enum.each(&MykonosBiennale.SearchReindex.enqueue_entity/1)
   end
 
   defp load_duplicate_groups(mode) do
-    ae_rt = Repo.get_by(RelationshipType, slug: "artwork_event")
-    ap_rt = Repo.get_by(RelationshipType, slug: "artwork_participant")
+    rt_slugs =
+      Repo.all(from rt in RelationshipType, where: rt.slug in ~w(artwork_event artwork_participant))
+      |> Enum.into(%{}, &{&1.slug, &1.id})
 
-    if ae_rt == nil or ap_rt == nil do
+    ae_rt_id = rt_slugs["artwork_event"]
+    ap_rt_id = rt_slugs["artwork_participant"]
+
+    if ae_rt_id == nil or ap_rt_id == nil do
       []
     else
-      artwork_event_rels =
+      rels =
         Repo.all(
           from r in Relationship,
-            where: r.relationship_type_id == ^ae_rt.id,
-            select: %{artwork_id: r.subject_id, event_id: r.object_id}
+            where: r.relationship_type_id in ^[ae_rt_id, ap_rt_id],
+            select: {r.relationship_type_id, r.subject_id, r.object_id}
         )
-
-      artwork_participant_rels =
-        Repo.all(
-          from r in Relationship,
-            where: r.relationship_type_id == ^ap_rt.id,
-            select: %{artwork_id: r.subject_id, participant_id: r.object_id}
-        )
-
-      ap_map = Enum.group_by(artwork_participant_rels, & &1.artwork_id, & &1.participant_id)
 
       artwork_ids =
-        (Enum.map(artwork_event_rels, & &1.artwork_id) ++
-           Enum.map(artwork_participant_rels, & &1.artwork_id))
+        rels |> Enum.map(&elem(&1, 1)) |> Enum.uniq()
+
+      artworks = Repo.all(from e in Entity, where: e.id in ^artwork_ids and e.type == "artwork")
+      artwork_map = Enum.into(artworks, %{}, &{&1.id, &1})
+
+      media_rows =
+        Repo.all(
+          from m in Media,
+            join: em in EntityMedia,
+              on: em.media_id == m.id,
+            where: em.entity_id in ^artwork_ids,
+            order_by: [em.entity_id, em.position],
+            select: {em.entity_id, m.id, m.source_type, m.source_path, m.source_url}
+        )
+
+      media_by_artwork =
+        Enum.reduce(media_rows, %{}, fn {eid, mid, st, sp, su}, acc ->
+          Map.update(acc, eid, [{mid, st, sp, su}], &(&1 ++ [{mid, st, sp, su}]))
+        end)
+
+      linked_ids =
+        rels
+        |> Enum.flat_map(fn
+          {rt_id, _, obj_id} when rt_id == ae_rt_id -> [obj_id]
+          {rt_id, _, obj_id} when rt_id == ap_rt_id -> [obj_id]
+          _ -> []
+        end)
         |> Enum.uniq()
 
-      artworks =
-        Repo.all(from e in Entity, where: e.id in ^artwork_ids)
-        |> Enum.into(%{}, fn e -> {e.id, e} end)
+      linked = Repo.all(from e in Entity, where: e.id in ^linked_ids)
+      linked_map = Enum.into(linked, %{}, &{&1.id, &1})
 
-      artwork_event_rels
-      |> Enum.flat_map(fn %{artwork_id: aid, event_id: eid} ->
+      ae_rels = Enum.filter(rels, fn {rt, _, _} -> rt == ae_rt_id end)
+      ap_rels = Enum.filter(rels, fn {rt, _, _} -> rt == ap_rt_id end)
+
+      ap_map = Enum.group_by(ap_rels, &elem(&1, 1), &elem(&1, 2))
+
+      ae_rels
+      |> Enum.flat_map(fn {_, aid, eid} ->
         pids = Map.get(ap_map, aid, [])
 
         for pid <- pids do
-          artwork = Map.get(artworks, aid)
+          artwork = Map.get(artwork_map, aid)
 
           if artwork do
             title_slug = slugify(artwork.fields["title"] || "")
@@ -105,13 +236,12 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.Merge do
             {e, p, _} -> {e, p}
           end
 
-        event = Repo.get(Entity, eid)
-        participant = Repo.get(Entity, pid)
+        event = Map.get(linked_map, eid)
+        participant = Map.get(linked_map, pid)
 
         artwork_entries =
           Enum.map(artwork_entities, fn a ->
-            media = Content.list_media_for_entity(a)
-            %{artwork: a, media: media}
+            %{artwork: a, media: Map.get(media_by_artwork, a.id, [])}
           end)
 
         %{
@@ -127,115 +257,70 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.Merge do
     end
   end
 
-  @impl true
-  def handle_event("toggle_select", %{"id" => id_str}, socket) do
-    id = String.to_integer(id_str)
-    selected = socket.assigns.selected_ids
-
-    new_selected =
-      if MapSet.member?(selected, id) do
-        MapSet.delete(selected, id)
-      else
-        MapSet.put(selected, id)
-      end
-
-    {:noreply, assign(socket, :selected_ids, new_selected)}
-  end
-
-  def handle_event("merge_selected", _, socket) do
-    groups = socket.assigns.duplicate_groups
-    selected = socket.assigns.selected_ids
-
-    {merged, new_groups} =
-      Enum.reduce(groups, {0, []}, fn group, {count, acc} ->
-        group_ids = Enum.map(group.entries, & &1.artwork.id)
-        selected_in_group = group_ids |> Enum.filter(&MapSet.member?(selected, &1))
-
-        cond do
-          length(group.entries) < 2 ->
-            {count, [group | acc]}
-
-          length(selected_in_group) == 0 ->
-            {count, [group | acc]}
-
-          true ->
-            survivor_id = hd(selected_in_group)
-            to_merge = Enum.reject(group.entries, fn e -> e.artwork.id == survivor_id end)
-
-            survivor_entry = Enum.find(group.entries, &(&1.artwork.id == survivor_id))
-
-            merge_artworks!(survivor_entry, to_merge)
-
-            new_entries = [
-              %{
-                artwork: Repo.get!(Entity, survivor_id),
-                media: Content.list_media_for_entity(Repo.get!(Entity, survivor_id))
-              }
-            ]
-
-            new_group = %{group | entries: new_entries}
-
-            if length(new_entries) > 1 do
-              {count + 1, [new_group | acc]}
-            else
-              {count + 1, acc}
-            end
-        end
-      end)
-
-    {:noreply,
-     socket
-     |> assign(:merged_count, merged)
-     |> assign(:duplicate_groups, new_groups)
-     |> assign(:selected_ids, MapSet.new())}
-  end
-
   defp merge_artworks!(survivor_entry, to_merge) do
     survivor = survivor_entry.artwork
+    duplicate_ids = Enum.map(to_merge, & &1.artwork.id)
 
-    for entry <- to_merge do
-      duplicate = entry.artwork
-      duplicate_media = entry.media
+    all_dup_media =
+      Enum.flat_map(to_merge, fn entry ->
+        Enum.map(entry.media, fn {mid, st, sp, su} ->
+          {entry.artwork.id, mid, st, sp, su}
+        end)
+      end)
 
-      for media <- duplicate_media do
-        caption =
-          if media.caption in [nil, ""], do: duplicate.fields["title"], else: media.caption
-
-        alt_text =
-          if media.alt_text in [nil, ""],
-            do: duplicate.fields["description"],
-            else: media.alt_text
-
-        {:ok, updated_media} =
-          Content.update_media(media, %{
-            caption: caption,
-            alt_text: alt_text
-          })
-
-        Content.attach_media_to_entity(survivor, updated_media)
-      end
-
-      Repo.delete_all(
+    survivor_media_ids =
+      Repo.all(
         from em in EntityMedia,
-          where: em.entity_id == ^duplicate.id
+          where: em.entity_id == ^survivor.id,
+          select: em.media_id
       )
+      |> MapSet.new()
 
-      unless survivor.fields["description"] not in [nil, ""] do
-        if duplicate.fields["description"] not in [nil, ""] do
-          survivor
-          |> Ecto.Changeset.change(
-            fields: Map.put(survivor.fields, "description", duplicate.fields["description"])
-          )
-          |> Repo.update!()
-        end
-      end
+    new_media_links =
+      all_dup_media
+      |> Enum.reject(fn {_, mid, _, _, _} -> MapSet.member?(survivor_media_ids, mid) end)
 
-      Repo.delete_all(
-        from r in Relationship,
-          where: r.subject_id == ^duplicate.id or r.object_id == ^duplicate.id
-      )
+    max_pos =
+      Repo.one(
+        from em in EntityMedia,
+          where: em.entity_id == ^survivor.id,
+          select: coalesce(max(em.position), -1)
+      ) || -1
 
-      Content.delete_entity(duplicate)
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    {rows, _final_pos} =
+      Enum.map_reduce(new_media_links, max_pos + 1, fn {_, mid, _, _, _}, pos ->
+        {[
+           entity_id: survivor.id,
+           media_id: mid,
+           position: pos,
+           metadata: %{},
+           inserted_at: now,
+           updated_at: now
+         ], pos + 1}
+      end)
+
+    if rows != [] do
+      Repo.insert_all(EntityMedia, rows)
+    end
+
+    dup_description =
+      Enum.find_value(to_merge, fn entry ->
+        d = entry.artwork.fields["description"]
+        if d not in [nil, ""], do: d, else: nil
+      end)
+
+    if survivor.fields["description"] in [nil, ""] and dup_description do
+      survivor
+      |> Ecto.Changeset.change(fields: Map.put(survivor.fields, "description", dup_description))
+      |> Repo.update!()
+    end
+
+    if duplicate_ids != [] do
+      Repo.delete_all(from em in EntityMedia, where: em.entity_id in ^duplicate_ids)
+      Repo.delete_all(from r in Relationship, where: r.subject_id in ^duplicate_ids or r.object_id in ^duplicate_ids)
+      Repo.delete_all(from e in Entity, where: e.id in ^duplicate_ids)
     end
   end
 
@@ -249,14 +334,18 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.Merge do
 
   defp first_media([]), do: nil
 
-  defp first_media([%{source_type: "upload", source_path: path} | _]) when is_binary(path),
-    do: %{source_type: "upload", source_path: path}
-
-  defp first_media([%{source_type: "url", source_url: url} | _]) when is_binary(url),
-    do: %{source_type: "url", source_url: url}
+  defp first_media([{_mid, source_type, source_path, source_url} | _]) do
+    %{source_type: source_type, source_path: source_path, source_url: source_url}
+  end
 
   defp first_media([_ | rest]), do: first_media(rest)
-  defp first_media(_), do: nil
+
+  defp media_thumb_url(%{source_type: "upload", source_path: path}) when is_binary(path) do
+    MykonosBiennale.Uploads.media_url(%Media{source_type: "upload", source_path: path}, size: "admin")
+  end
+
+  defp media_thumb_url(%{source_type: "url", source_url: url}) when is_binary(url), do: url
+  defp media_thumb_url(_), do: nil
 
   defp slugify(nil), do: ""
 

--- a/lib/mykonos_biennale_web/live/admin/artwork_live/merge.html.heex
+++ b/lib/mykonos_biennale_web/live/admin/artwork_live/merge.html.heex
@@ -8,7 +8,7 @@
         <h1 class="text-3xl font-bold text-white">Merge Duplicate Artworks</h1>
       </div>
       <div class="flex items-center gap-4">
-        <span class="text-sm text-gray-400">{length(@duplicate_groups)} groups</span>
+        <span class="text-sm text-gray-400">{@all_groups_count} groups · page {@page}/{@total_pages}</span>
         <%= if @merged_count > 0 do %>
           <span class="text-sm text-green-400">{@merged_count} groups merged</span>
         <% end %>
@@ -36,6 +36,30 @@
         >
           Merge Selected
         </button>
+        <button
+          phx-click="merge_all"
+          data-confirm="This will auto-merge ALL duplicate groups (keeping lowest ID as survivor). Continue?"
+          class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          Merge All ({@all_groups_count} groups)
+        </button>
+        <%= if @total_pages > 1 do %>
+          <div class="flex items-center gap-2">
+            <.link
+              patch={"/admin/artworks/merge?page=#{max(@page - 1, 1)}"}
+              class={if @page == 1, do: "px-3 py-1.5 text-sm text-gray-600", else: "px-3 py-1.5 text-sm text-gray-400 hover:text-white"}
+            >
+              Prev
+            </.link>
+            <span class="text-sm text-gray-500">{@page} / {@total_pages}</span>
+            <.link
+              patch={"/admin/artworks/merge?page=#{min(@page + 1, @total_pages)}"}
+              class={if @page == @total_pages, do: "px-3 py-1.5 text-sm text-gray-600", else: "px-3 py-1.5 text-sm text-gray-400 hover:text-white"}
+            >
+              Next
+            </.link>
+          </div>
+        <% end %>
       </div>
     </div>
 
@@ -97,11 +121,11 @@
                   <div class="w-28 rounded-lg overflow-hidden border-2 border-transparent peer-checked:border-green-500 hover:border-gray-500 transition-colors">
                     <div class="aspect-square bg-gray-700 flex items-center justify-center">
                       <%= case first_media(entry.media) do %>
-                        <% %{source_type: "upload"} = media -> %>
-                          <.picture
-                            record={media}
-                            size="admin"
+                        <% %{source_type: "upload"} = m -> %>
+                          <img
+                            src={media_thumb_url(m)}
                             alt={pfield(entry.artwork, "title")}
+                            class="w-full h-full object-cover"
                           />
                         <% %{source_type: "url", source_url: url} -> %>
                           <img

--- a/lib/mykonos_biennale_web/live/admin/artwork_live/reimport_preview.ex
+++ b/lib/mykonos_biennale_web/live/admin/artwork_live/reimport_preview.ex
@@ -1,0 +1,110 @@
+defmodule MykonosBiennaleWeb.Admin.ArtworkLive.ReimportPreview do
+  use MykonosBiennaleWeb, :live_view
+
+  import Ecto.Query, warn: false
+
+  alias MykonosBiennale.Repo
+  alias MykonosBiennale.ReimportArtworks
+  alias MykonosBiennale.Content.{Media, EntityMedia}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:groups, [])
+      |> assign(:page, 1)
+      |> assign(:per_page, 20)
+      |> assign(:total_pages, 1)
+      |> assign(:total_groups, 0)
+      |> assign(:total_records, 0)
+      |> assign(:dup_groups, 0)
+      |> assign(:media_matched, 0)
+      |> assign(:media_unmatched, 0)
+      |> assign(:imported, false)
+      |> assign(:import_result, nil)
+      |> assign(:loading, true)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    if socket.assigns.groups == [] do
+      groups = ReimportArtworks.build_groups()
+      media_index = ReimportArtworks.build_media_index()
+
+      {matched, unmatched} =
+        Enum.reduce(groups, {0, 0}, fn group, {m, u} ->
+          cnt =
+            Enum.count(group.file_names, fn f -> Map.has_key?(media_index, f) end)
+
+          {m + cnt, u + (length(group.file_names) - cnt)}
+        end)
+
+      total_records = Enum.sum(Enum.map(groups, & &1.count))
+      dup_groups = Enum.count(groups, &(&1.count > 1))
+
+      {:noreply,
+       socket
+       |> assign(:groups, groups)
+       |> assign(:total_groups, length(groups))
+       |> assign(:total_records, total_records)
+       |> assign(:dup_groups, dup_groups)
+       |> assign(:media_matched, matched)
+       |> assign(:media_unmatched, unmatched)
+       |> assign(:loading, false)
+       |> assign_page(String.to_integer(params["page"] || "1"))}
+    else
+      {:noreply, assign_page(socket, String.to_integer(params["page"] || "1"))}
+    end
+  end
+
+  defp assign_page(socket, page) do
+    total_pages = max(1, ceil(socket.assigns.total_groups / socket.assigns.per_page))
+    page = min(page, total_pages)
+    offset = (page - 1) * socket.assigns.per_page
+    page_groups = Enum.slice(socket.assigns.groups, offset, socket.assigns.per_page)
+
+    socket
+    |> assign(:page, page)
+    |> assign(:total_pages, total_pages)
+    |> assign(:page_groups, page_groups)
+  end
+
+  @impl true
+  def handle_event("do_import", _, socket) do
+    {deleted, _ids} = ReimportArtworks.delete_existing_artworks()
+    {created, errors} = ReimportArtworks.import_groups(socket.assigns.groups)
+
+    {:noreply,
+     socket
+     |> assign(:imported, true)
+     |> assign(:import_result, %{deleted: deleted, created: created, errors: errors})}
+  end
+
+  defp media_thumb(nil), do: nil
+
+  defp media_thumb(filename) do
+    media_index = get_media_index()
+
+    case Map.get(media_index, filename) do
+      nil ->
+        nil
+
+      {_id, path} ->
+        MykonosBiennale.Uploads.media_url(
+          %Media{source_type: "upload", source_path: path},
+          size: "admin"
+        )
+    end
+  end
+
+  defp get_media_index do
+    Process.get(:media_index) ||
+      (
+        idx = ReimportArtworks.build_media_index()
+        Process.put(:media_index, idx)
+        idx
+      )
+  end
+end

--- a/lib/mykonos_biennale_web/live/admin/artwork_live/reimport_preview.html.heex
+++ b/lib/mykonos_biennale_web/live/admin/artwork_live/reimport_preview.html.heex
@@ -1,0 +1,145 @@
+<Layouts.app flash={@flash}>
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="flex items-center justify-between mb-6">
+      <div class="flex items-center gap-4">
+        <.link patch="/admin/artworks" class="text-gray-400 hover:text-white transition-colors">
+          <.icon name="hero-arrow-left" class="w-5 h-5" />
+        </.link>
+        <h1 class="text-3xl font-bold text-white">Artwork Reimport Preview</h1>
+      </div>
+    </div>
+
+    <%= if @loading do %>
+      <div class="text-center py-12">
+        <p class="text-gray-400">Loading export data...</p>
+      </div>
+    <% else %>
+      <div class="bg-gray-800/30 backdrop-blur-sm rounded-lg border border-purple-500/20 p-4 mb-6">
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-4 text-center">
+          <div>
+            <div class="text-2xl font-bold text-white">{@total_groups}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wider">Unique Artworks</div>
+          </div>
+          <div>
+            <div class="text-2xl font-bold text-white">{@total_records}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wider">Source Records</div>
+          </div>
+          <div>
+            <div class="text-2xl font-bold text-yellow-400">{@dup_groups}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wider">Duplicate Groups</div>
+          </div>
+          <div>
+            <div class="text-2xl font-bold text-green-400">{@media_matched}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wider">Media Matched</div>
+          </div>
+          <div>
+            <div class="text-2xl font-bold text-red-400">{@media_unmatched}</div>
+            <div class="text-xs text-gray-500 uppercase tracking-wider">Media Unmatched</div>
+          </div>
+        </div>
+      </div>
+
+      <%= if @imported do %>
+        <div class="bg-green-900/30 border border-green-500/30 rounded-lg p-4 mb-6">
+          <p class="text-green-300 font-medium">
+            Import complete: {@import_result.deleted} artworks deleted, {@import_result.created} created, {@import_result.errors} errors
+          </p>
+        </div>
+      <% else %>
+        <div class="bg-red-900/20 border border-red-500/30 rounded-lg p-4 mb-6">
+          <p class="text-red-300 text-sm font-medium mb-2">
+            This will DELETE all existing artwork entities and reimport from the export file.
+            Media files on disk are preserved and will be relinked.
+          </p>
+          <button
+            phx-click="do_import"
+            data-confirm="This will delete ALL existing artworks and reimport. Are you sure?"
+            class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors"
+          >
+            Delete & Reimport All Artworks
+          </button>
+        </div>
+      <% end %>
+
+      <%= if @total_pages > 1 do %>
+        <div class="flex items-center gap-2 mb-4">
+          <.link
+            patch={"/admin/artworks/import_preview?page=#{max(@page - 1, 1)}"}
+            class={if @page == 1, do: "px-3 py-1.5 text-sm text-gray-600", else: "px-3 py-1.5 text-sm text-gray-400 hover:text-white"}
+          >
+            Prev
+          </.link>
+          <span class="text-sm text-gray-500">{@page} / {@total_pages}</span>
+          <.link
+            patch={"/admin/artworks/import_preview?page=#{min(@page + 1, @total_pages)}"}
+            class={if @page == @total_pages, do: "px-3 py-1.5 text-sm text-gray-600", else: "px-3 py-1.5 text-sm text-gray-400 hover:text-white"}
+          >
+            Next
+          </.link>
+        </div>
+      <% end %>
+
+      <div class="space-y-3">
+        <%= for group <- @page_groups do %>
+          <div class="bg-gray-800/30 backdrop-blur-sm rounded-lg border border-gray-700 p-4">
+            <div class="flex items-center gap-6 mb-3">
+              <div class="flex-shrink-0">
+                <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Title</span>
+                <div class="text-white text-sm font-medium">{group.title}</div>
+              </div>
+              <div class="flex-shrink-0">
+                <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Artist</span>
+                <div class="text-white text-sm">{group.artist_name}</div>
+              </div>
+              <div class="flex-shrink-0">
+                <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Year</span>
+                <div class="text-white text-sm">{group.year}</div>
+              </div>
+              <div class="flex-shrink-0">
+                <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Project</span>
+                <div class="text-white text-sm">{group.project_slug}</div>
+              </div>
+              <div class="flex-shrink-0">
+                <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Biennale</span>
+                <div class="text-white text-sm">{group.biennale_title}</div>
+              </div>
+              <div class="flex-shrink-0">
+                <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Records</span>
+                <div class={"text-sm font-medium " <> if group.count > 1, do: "text-yellow-400", else: "text-gray-400"}>{group.count}</div>
+              </div>
+              <div class="flex-shrink-0">
+                <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Media</span>
+                <div class="text-sm text-gray-400">{length(group.file_names)} files</div>
+              </div>
+            </div>
+
+            <%= if group.description != "" do %>
+              <div class="text-xs text-gray-500 mb-3 line-clamp-2">{group.description}</div>
+            <% end %>
+
+            <div class="flex flex-wrap gap-2">
+              <%= for filename <- group.file_names do %>
+                <% thumb = media_thumb(filename) %>
+                <div class="w-20 h-20 rounded-lg overflow-hidden bg-gray-700 flex items-center justify-center border border-gray-600">
+                  <%= if thumb do %>
+                    <img src={thumb} alt={filename} class="w-full h-full object-cover" />
+                  <% else %>
+                    <div class="text-xs text-gray-600 text-center px-1">
+                      {String.slice(filename, -20, 20)}
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+
+            <%= if group.count > 1 do %>
+              <div class="mt-2 text-xs text-gray-600">
+                Merging PKs: {Enum.join(group.pks, ", ")}
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</Layouts.app>

--- a/lib/mykonos_biennale_web/live/admin/artwork_live/show.ex
+++ b/lib/mykonos_biennale_web/live/admin/artwork_live/show.ex
@@ -5,11 +5,17 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.Show do
 
   alias MykonosBiennale.Repo
   alias MykonosBiennale.Content
-  alias MykonosBiennale.Content.{Entity, Relationship, RelationshipType}
+  alias MykonosBiennale.Content.{Entity, Media, Relationship, RelationshipType, EntityMedia}
+  alias MykonosBiennale.Workers.MediaProcess
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, socket |> assign(:active_tab, "default")}
+    {:ok,
+     socket
+     |> assign(:active_tab, "default")
+     |> assign(:move_media_id, nil)
+     |> assign(:move_search, "")
+     |> assign(:move_results, [])}
   end
 
   @impl true
@@ -26,7 +32,10 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.Show do
      |> assign(:artwork, artwork)
      |> assign(:participants, participants)
      |> assign(:events, events)
-     |> assign(:media, media)}
+     |> assign(:media, media)
+     |> assign(:move_media_id, nil)
+     |> assign(:move_search, "")
+     |> assign(:move_results, [])}
   end
 
   defp show_relationship_query do
@@ -73,6 +82,90 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.Show do
     {:noreply, assign(socket, :active_tab, tab)}
   end
 
+  def handle_event("start_move_media", %{"media-id" => media_id}, socket) do
+    {:noreply,
+     socket
+     |> assign(:move_media_id, String.to_integer(media_id))
+     |> assign(:move_search, "")
+     |> assign(:move_results, [])}
+  end
+
+  def handle_event("cancel_move_media", _, socket) do
+    {:noreply,
+     socket
+     |> assign(:move_media_id, nil)
+     |> assign(:move_search, "")
+     |> assign(:move_results, [])}
+  end
+
+  def handle_event("search_artwork", %{"search" => search}, socket) do
+    results =
+      if String.trim(search) == "" do
+        []
+      else
+        pattern = "%#{String.downcase(search)}%"
+
+        Repo.all(
+          from e in Entity,
+            where:
+              e.type == "artwork" and
+                e.id != ^socket.assigns.artwork.id and
+                (ilike(fragment("lower(?)", e.identity), ^pattern) or
+                   ilike(fragment("lower(?->>'title')", e.fields), ^pattern)),
+            limit: 10,
+            select: {e.id, e.identity, fragment("?->>'date'", e.fields)}
+        )
+      end
+
+    {:noreply,
+     socket
+     |> assign(:move_search, search)
+     |> assign(:move_results, results)}
+  end
+
+  def handle_event("move_media", %{"target-id" => target_id_str}, socket) do
+    target_id = String.to_integer(target_id_str)
+    media_id = socket.assigns.move_media_id
+    artwork = socket.assigns.artwork
+
+    media = Repo.get!(Media, media_id)
+    target = Content.get_artwork!(target_id)
+
+    {:ok, :detached} = Content.detach_media_from_entity(artwork, media)
+    {:ok, _} = Content.attach_media_to_entity(target, media)
+
+    media_list = Content.list_media_for_entity(artwork)
+
+    {:noreply,
+     socket
+     |> assign(:media, media_list)
+     |> assign(:move_media_id, nil)
+     |> assign(:move_search, "")
+     |> assign(:move_results, [])
+     |> put_flash(:info, "Media moved to #{target.identity}")}
+  end
+
+  def handle_event("remove_media", %{"media-id" => media_id}, socket) do
+    artwork = socket.assigns.artwork
+    media = Repo.get!(Media, String.to_integer(media_id))
+    {:ok, :detached} = Content.detach_media_from_entity(artwork, media)
+
+    media_list = Content.list_media_for_entity(artwork)
+
+    {:noreply,
+     socket
+     |> assign(:media, media_list)
+     |> put_flash(:info, "Media removed")}
+  end
+
+  def handle_event("rotate_media", %{"media-id" => media_id, "degrees" => degrees}, socket) do
+    media = Repo.get!(Media, String.to_integer(media_id))
+    MediaProcess.enqueue_rotate(media.id, String.to_integer(degrees))
+
+    {:noreply,
+     put_flash(socket, :info, "Rotation #{degrees}° queued for #{media.original_name || media.caption}")}
+  end
+
   def handle_info({:fields_changed, %{content: content}}, socket) do
     case Jason.decode(content) do
       {:ok, new_fields} ->
@@ -96,4 +189,11 @@ defmodule MykonosBiennaleWeb.Admin.ArtworkLive.Show do
   end
 
   defp field(%Entity{}, _key, default), do: default
+
+  defp media_thumb(%Media{source_type: "upload"} = m) do
+    MykonosBiennale.Uploads.media_url(m, size: "thumb")
+  end
+
+  defp media_thumb(%Media{source_type: "url", source_url: url}) when is_binary(url), do: url
+  defp media_thumb(_), do: nil
 end

--- a/lib/mykonos_biennale_web/live/admin/artwork_live/show.html.heex
+++ b/lib/mykonos_biennale_web/live/admin/artwork_live/show.html.heex
@@ -7,12 +7,21 @@
         </.link>
         <h1 class="text-3xl font-bold text-white">{field(@artwork, "title")}</h1>
       </div>
-      <.link
-        patch={"/admin/artworks/#{@artwork.id}/edit"}
-        class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
-      >
-        Edit
-      </.link>
+      <div class="flex items-center gap-2">
+        <.link
+          href={"/art/#{@artwork.id}"}
+          target="_blank"
+          class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          See on Site
+        </.link>
+        <.link
+          patch={"/admin/artworks/#{@artwork.id}/edit"}
+          class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          Edit
+        </.link>
+      </div>
     </div>
 
     <div class="flex gap-2 mb-6">
@@ -122,38 +131,123 @@
       <%= if @media != [] do %>
         <div class="mt-6">
           <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3 block">
-            Media
+            Media ({length(@media)})
           </span>
           <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
             <%= for m <- @media do %>
               <div class="bg-gray-800/30 rounded-lg overflow-hidden border border-gray-700/30">
-                <div class="aspect-video bg-gray-700 flex items-center justify-center">
+                <div class="aspect-video bg-gray-700 flex items-center justify-center relative group">
                   <%= case m.source_type do %>
                     <% "upload" -> %>
                       <%= if m.source_path do %>
-                        <.picture record={m} size="thumb" alt={m.alt_text || m.caption} />
+                        <img src={media_thumb(m)} alt={m.alt_text || m.caption} class="w-full h-full object-cover" />
                       <% else %>
                         <.icon name="hero-photo" class="w-8 h-8 text-gray-400" />
                       <% end %>
                     <% "url" -> %>
                       <%= if m.source_url do %>
-                        <img
-                          src={m.source_url}
-                          alt={m.alt_text || m.caption}
-                          class="w-full h-full object-cover"
-                        />
+                        <img src={m.source_url} alt={m.alt_text || m.caption} class="w-full h-full object-cover" />
                       <% else %>
                         <.icon name="hero-link" class="w-8 h-8 text-gray-400" />
                       <% end %>
                     <% "embed" -> %>
                       <.icon name="hero-video-camera" class="w-8 h-8 text-gray-400" />
                   <% end %>
+                  <div class="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-1 flex-wrap p-2">
+                    <button
+                      phx-click="rotate_media"
+                      phx-value-media-id={m.id}
+                      phx-value-degrees="90"
+                      class="px-2 py-1 bg-gray-600 hover:bg-gray-500 text-white text-xs rounded transition-colors"
+                      title="Rotate 90° clockwise"
+                    >
+                      90°
+                    </button>
+                    <button
+                      phx-click="rotate_media"
+                      phx-value-media-id={m.id}
+                      phx-value-degrees="180"
+                      class="px-2 py-1 bg-gray-600 hover:bg-gray-500 text-white text-xs rounded transition-colors"
+                      title="Rotate 180°"
+                    >
+                      180°
+                    </button>
+                    <button
+                      phx-click="rotate_media"
+                      phx-value-media-id={m.id}
+                      phx-value-degrees="270"
+                      class="px-2 py-1 bg-gray-600 hover:bg-gray-500 text-white text-xs rounded transition-colors"
+                      title="Rotate 270° (or -90°)"
+                    >
+                      270°
+                    </button>
+                    <button
+                      phx-click="start_move_media"
+                      phx-value-media-id={m.id}
+                      class="px-2 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded transition-colors"
+                    >
+                      Move
+                    </button>
+                    <button
+                      phx-click="remove_media"
+                      phx-value-media-id={m.id}
+                      data-confirm="Remove this media from the artwork?"
+                      class="px-2 py-1 bg-red-600 hover:bg-red-700 text-white text-xs rounded transition-colors"
+                    >
+                      Remove
+                    </button>
+                  </div>
                 </div>
                 <%= if m.caption do %>
                   <div class="px-2 py-1 text-xs text-gray-400 truncate">{m.caption}</div>
                 <% end %>
+                <%= if m.original_name do %>
+                  <div class="px-2 pb-1 text-[10px] text-gray-600 truncate" title={m.original_name}>{m.original_name}</div>
+                <% end %>
               </div>
             <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <%= if @move_media_id do %>
+        <div class="fixed inset-0 bg-black/70 flex items-center justify-center z-50" phx-click="cancel_move_media">
+          <div class="bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4" phx-click={nil}>
+            <h2 class="text-lg font-bold text-white mb-4">Move media to artwork</h2>
+            <form phx-submit="search_artwork" phx-change="search_artwork">
+              <input
+                type="text"
+                name="search"
+                value={@move_search}
+                placeholder="Search by title or artist..."
+                phx-debounce="300"
+                class="w-full px-3 py-2 bg-gray-700 text-white rounded-lg border border-gray-600 focus:border-blue-500 focus:outline-none mb-3"
+              />
+            </form>
+            <div class="max-h-64 overflow-y-auto space-y-1">
+              <%= for {id, identity, date} <- @move_results do %>
+                <button
+                  phx-click="move_media"
+                  phx-value-target-id={id}
+                  class="w-full text-left px-3 py-2 bg-gray-700/50 hover:bg-blue-600/30 rounded-lg transition-colors"
+                >
+                  <span class="text-white text-sm">{identity}</span>
+                  <%= if date do %>
+                    <span class="text-gray-500 text-xs ml-2">{date}</span>
+                  <% end %>
+                  <span class="text-gray-600 text-xs ml-2">#{id}</span>
+                </button>
+              <% end %>
+              <%= if @move_search != "" and @move_results == [] do %>
+                <p class="text-gray-500 text-sm text-center py-4">No results found</p>
+              <% end %>
+            </div>
+            <button
+              phx-click="cancel_move_media"
+              class="mt-4 w-full px-3 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
           </div>
         </div>
       <% end %>

--- a/lib/mykonos_biennale_web/router.ex
+++ b/lib/mykonos_biennale_web/router.ex
@@ -18,18 +18,34 @@ defmodule MykonosBiennaleWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :static_media do
+    plug :accepts, ["html"]
+    plug :put_secure_browser_headers
+  end
+
   scope "/", MykonosBiennaleWeb do
     pipe_through :browser
 
     get "/", PageController, :home
-    get "/media/:dimensions/:filename", MediaController, :show
-    get "/media/:filename", MediaController, :show_slug
+  end
+
+  scope "/media", MykonosBiennaleWeb do
+    pipe_through :static_media
+
+    get "/:dimensions/:filename", MediaController, :show
+    get "/:filename", MediaController, :show_slug
+  end
+
+  scope "/", MykonosBiennaleWeb do
+    pipe_through :browser
     live "/archive", ArchiveLive
     live "/archive/:year", ArchiveDetailLive
     live "/program", ProgramLive
     live "/about", AboutLive
     live "/search", PublicSearchLive
     get "/page/:slug", SitePageController, :show
+    get "/art/:id", ArtworkController, :show
+    get "/art/s/:slug", ArtworkController, :show_by_slug
     get "/biennale/:slug", BiennaleController, :show
     get "/biennale/:slug/festival", BiennaleController, :show
   end
@@ -91,6 +107,7 @@ defmodule MykonosBiennaleWeb.Router do
       live "/admin/films/:id/edit", Admin.FilmLive.Index, :edit
       live "/admin/films/:id", Admin.FilmLive.Show, :show
       live "/admin/artworks", Admin.ArtworkLive.Index, :index
+      live "/admin/artworks/import_preview", Admin.ArtworkLive.ReimportPreview, :index
       live "/admin/artworks/merge", Admin.ArtworkLive.Merge, :index
       live "/admin/artworks/new", Admin.ArtworkLive.Index, :new
       live "/admin/artworks/:id/edit", Admin.ArtworkLive.Index, :edit

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MykonosBiennale.MixProject do
   def project do
     [
       app: :mykonos_biennale,
-      version: "0.1.2",
+      version: "0.1.4",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
… 0-9a-zA-Z), which produced slugs differing only in case (e.g. antidote-box-09u vs antidote-box-09U). On macOS's case-insensitive filesystem, their thumbnail files collided — 87 colliding pairs total.

Changes:
lib/mykonos_biennale/media_slug.ex — switched from base62 to base36 (0-9a-z only), eliminating uppercase from slug suffixes Regenerated all 2,836 media slugs in the DB (batched SQL UPDATE via VALUES) Cleared all cached thumbnails in priv/static/media/ (regenerate on-demand) Fixed admin media_thumb/1 to pass the full media struct (including slug) instead of reconstructing without it